### PR TITLE
Disable the 'Next' button if no checkbox items selected

### DIFF
--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -27,7 +27,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ options, multiSelectSubmit }
           ))}
         </Group>
       </Checkbox.Group>
-      {multiSelectSubmit && <Button onClick={() => multiSelectSubmit(selected)}>Next</Button>}
+      {multiSelectSubmit && <Button onClick={() => multiSelectSubmit(selected)} disabled={selected.length == 0}>Next</Button>}
     </>
   );
 };


### PR DESCRIPTION
Disabling the 'Next' button on Multi-select prompt pages until at least one selection has been made. 