### PR TITLE
Feature remove unnecessary hexagons temporarily

### DIFF
--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -6,7 +6,7 @@ import AvatarDisplay from 'components/ui/AvatarDisplay/AvatarDisplay';
 import router from 'next/router';
 import { FC } from 'react';
 
-interface OutcomePanelProps { }
+interface OutcomePanelProps {}
 
 export const OutcomePanel: FC<OutcomePanelProps> = () => {
   const gameInfoContext = useGameInfoContext();
@@ -26,7 +26,7 @@ export const OutcomePanel: FC<OutcomePanelProps> = () => {
     <TwoColumnLayout
       leftColumn={
         <Center>
-          <Stack direction={{ base: 'row', lg: 'column' }}>
+          <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>
             {gameInfoContext.avatar?.fileUrl !== undefined && gameInfoContext?.persona !== undefined && (
               <AvatarDisplay fileUrl={gameInfoContext.avatar?.fileUrl} name={gameInfoContext?.persona.name} />
             )}

--- a/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
+++ b/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
@@ -10,7 +10,6 @@ interface PromptProps {
 }
 
 export const CurrentPrompt: FC<PromptProps> = ({ prompt, answerSelected }) => {
-  
   const optionSelected = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
     const option = prompt?.options?.results.find((o: IOption) => o.value === e.currentTarget.value);
     if (option === undefined) {

--- a/src/components/Prompts/PromptPanel/PromptPanel.tsx
+++ b/src/components/Prompts/PromptPanel/PromptPanel.tsx
@@ -8,7 +8,7 @@ import { IAnswer, IOption, IPrompt } from 'models';
 import router from 'next/router';
 import React, { FC, useEffect } from 'react';
 
-interface PromptPanelProps { }
+interface PromptPanelProps {}
 
 export const PromptPanel: FC<PromptPanelProps> = () => {
   let gameInfoContext = useGameInfoContext();
@@ -144,7 +144,7 @@ export const PromptPanel: FC<PromptPanelProps> = () => {
     <TwoColumnLayout
       leftColumn={
         <Center>
-          <Stack direction={{ base: 'row', lg: 'column' }}>
+          <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>
             {gameInfoContext.avatar?.fileUrl !== undefined && gameInfoContext?.persona !== undefined && (
               <AvatarDisplay fileUrl={gameInfoContext.avatar?.fileUrl} name={gameInfoContext?.persona.name} />
             )}

--- a/src/components/ui/HexagonCollection/HexagonCollection.tsx
+++ b/src/components/ui/HexagonCollection/HexagonCollection.tsx
@@ -33,8 +33,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
       {loading ? (
         <Loading message="Loading Achievements..." />
       ) : (
-        <SimpleGrid templateColumns={{ base: '1fr 1fr 1fr 1fr', lg: '1fr 1fr 1fr' }}
-          spacing="2px" gap="10px">
+        <SimpleGrid templateColumns={{ base: '1fr 1fr 1fr 1fr', lg: '1fr 1fr 1fr' }} spacing="2px" gap="10px">
           <HexagonItem
             productName="XM Cloud"
             icon="0f7f9565544a42c19371f215bd57cc0d"
@@ -43,7 +42,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
               requiredProducts != undefined && requiredProducts.find((x) => x == TargetProduct.xmCloud) ? true : false
             }
           />
-          <HexagonItem
+          {/* <HexagonItem
             productName="Content Operations"
             icon="d23e3e8b102746ed8b0a60758e2bd58c"
             cloud="Content"
@@ -52,7 +51,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
                 ? true
                 : false
             }
-          />
+          /> */}
           <HexagonItem
             productName="Sitecore Search"
             icon="7e75e5619d514d3893c4079d291e4776"
@@ -61,7 +60,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
               requiredProducts != undefined && requiredProducts.find((x) => x == TargetProduct.search) ? true : false
             }
           />
-          <HexagonItem
+          {/* <HexagonItem
             productName="Sitecore DAM"
             icon="d4460059f7f74238bb65b760a8fa6859"
             cloud="Content"
@@ -80,7 +79,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
                 ? true
                 : false
             }
-          />
+          /> */}
           <HexagonItem
             productName="Sitecore Send"
             icon="e021e8eba3cd42d295458bb7fb064d77"
@@ -107,7 +106,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
                 : false
             }
           />
-          <HexagonItem
+          {/* <HexagonItem
             productName="Sitecore Discover"
             icon="321e52cb1a654d6cbb4b741a36506548"
             cloud="Commerce"
@@ -122,7 +121,7 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
             active={
               requiredProducts != undefined && requiredProducts.find((x) => x == TargetProduct.connect) ? true : false
             }
-          />
+          /> */}
           <HexagonItem
             productName="Sitecore OrderCloud"
             icon="3eb03031027e456eb212d7c3ddf1295a"

--- a/src/components/ui/HexagonItem/HexagonItem.tsx
+++ b/src/components/ui/HexagonItem/HexagonItem.tsx
@@ -16,11 +16,11 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
         webkitFilter:
           'url(/images/hex-item-round-corners.svg#helix-round-borders) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
         filter: 'url(/images/hex-item-round-corners.svg#helix-round-borders) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
-        paddingBottom: '10px',
         transition: 'opacity 0.3s',
         pointerEvents: 'none',
-        minHeight: '100px',
       }}
+      minH={{ base: '40px', lg: '100px' }}
+      paddingBottom="10px"
     >
       <Box
         sx={{
@@ -57,26 +57,22 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
           textAlign: 'center',
           transition: 'transform 0.3s ease-out',
         }}
-        //className="hex-grid__content"
       >
         <Image
           className="hex-grid__content__icon"
           sx={{
-            width: 'auto',
-            height: '24px',
-            margin: '.75rem 0 .25rem 0',
             webkitFilter: 'brightness(0) invert(1) opacity(0.9)',
             filter: 'brightness(0) invert(1) opacity(0.9)',
           }}
           src={`https://sitecorecontenthub.stylelabs.cloud/api/public/content/${icon}`}
           alt={productName}
-          width={30}
-          height={30}
+          width="auto"
+          height={{ base: '16px', lg: '24px' }}
+          margin={{ base: '.25rem 0 .25rem 0', lg: '.75rem 0 .25rem 0' }}
         />
 
         <Show above="991px">
           <chakra.h3
-            className="hex-grid__content__title"
             sx={{
               margin: '0 10px 10px 10px',
               padding: '0 !important',

--- a/src/components/ui/HexagonItem/HexagonItem.tsx
+++ b/src/components/ui/HexagonItem/HexagonItem.tsx
@@ -19,6 +19,7 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
         paddingBottom: '10px',
         transition: 'opacity 0.3s',
         pointerEvents: 'none',
+        minHeight: '100px',
       }}
     >
       <Box
@@ -56,7 +57,7 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
           textAlign: 'center',
           transition: 'transform 0.3s ease-out',
         }}
-      //className="hex-grid__content"
+        //className="hex-grid__content"
       >
         <Image
           className="hex-grid__content__icon"
@@ -73,7 +74,7 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
           height={30}
         />
 
-        <Show above='991px'>
+        <Show above="991px">
           <chakra.h3
             className="hex-grid__content__title"
             sx={{
@@ -93,7 +94,6 @@ export const HexagonItem: FC<HexagonItemProps> = ({ productName, icon, cloud, ac
             {productName}
           </chakra.h3>
         </Show>
-
       </Box>
     </chakra.div>
   );

--- a/src/components/ui/Layout/TwoColumnLayout.tsx
+++ b/src/components/ui/Layout/TwoColumnLayout.tsx
@@ -23,7 +23,10 @@ export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
       backgroundAttachment="fixed"
       backgroundSize="cover"
       backgroundRepeat="no-repeat"
-    >      <Center>
+      paddingX={4}
+    >
+      {' '}
+      <Center>
         {loading ? (
           <Loading />
         ) : (
@@ -31,7 +34,7 @@ export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
             h="100%"
             w={{ base: '1200px' }}
             templateColumns={{ base: '1fr', lg: '1fr 2fr' }}
-            gap={0}
+            gap={{ base: 0, lg: 10 }}
             my={8}
             mx="auto"
           >

--- a/src/pages/prompt.tsx
+++ b/src/pages/prompt.tsx
@@ -3,7 +3,7 @@ import { Layout } from 'components/ui';
 
 const PromptPage = () => {
   return (
-    <Layout>
+    <Layout showSaveButton={false}>
       <PromptPanel />
     </Layout>
   );


### PR DESCRIPTION
This PR includes:

- Styling improvements related to Mobile and the Hexagons (or various elements related to them).
- Commented out the hexagons that we don't use.  Technically CDP is not in use, but it could be with another change, so I left that in there future now.  Current options are XMC, Personalize, CDP, Send, Order Cloud, and Search.