### PR TITLE
Bug Fixes related to a missing question

### DIFF
--- a/src/components/ui/Layout/SingleColumnLayout.tsx
+++ b/src/components/ui/Layout/SingleColumnLayout.tsx
@@ -21,6 +21,7 @@ export const SingleColumnLayout: FC<SingleColumnLayoutProps> = ({
       backgroundAttachment="fixed"
       backgroundSize="cover"
       backgroundRepeat="no-repeat"
+      paddingX={4}
     >
       <Center>
         {loading ? (

--- a/src/lib/NextPrompts.ts
+++ b/src/lib/NextPrompts.ts
@@ -71,7 +71,7 @@ const hydrateAndFilterOutNextPrompts = async (
   questionsBank: IPrompt[],
   answersBank: IAnswer[]
 ): Promise<IPrompt[] | undefined> => {
-  let nextValidatedPrompts: IPrompt[] | undefined = undefined;
+  let nextValidatedPrompts: IPrompt[] | undefined = [];
 
   if (promptIds && promptIds.length > 0) {
     // Get all prompts from prompt ids
@@ -104,5 +104,5 @@ const hydrateAndFilterOutNextPrompts = async (
     }
   }
 
-  return nextValidatedPrompts;
+  return questionsBank;
 };


### PR DESCRIPTION
Found a missing question that needed to be there (Search) and found a bug and fixed it.  While at it, I found the one column layout used on the settings page, was not consistent with the padding as the two column.  Both should be resolved.

To see the Search Question, you need to answer "XM" in the quiz.  To see other products if you are curious, Personalize shows up if you select XP and Historical Personalization.  Send will show up if you select XP and Marketing Automation from the features.  Lastly Order Cloud will show up if you select XC.