### PR TITLE
Bug/progress bar not complete

### DIFF
--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -27,6 +27,11 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
       showProgressBar={props.showProgressBar}
       showResetButton={props.showResetButton}
       showSaveButton={props.showSaveButton}
+      backgroundImage={
+        gameInfoContext.theme?.id == 'a5F4KpHzIkO1Re9iHmJjWA'
+          ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'
+          : '/corporate/background.jpg'
+      }
       leftColumn={
         <Center>
           <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>

--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -1,14 +1,14 @@
 import { Box, Center, Stack } from '@chakra-ui/react';
 import { OutcomeGenerator } from 'components/Outcomes';
 import { PreviousAnswers } from 'components/Prompts';
-import { HexagonCollection, TwoColumnLayout, useGameInfoContext } from 'components/ui';
+import { HexagonCollection, LayoutProps, TwoColumnLayout, useGameInfoContext } from 'components/ui';
 import AvatarDisplay from 'components/ui/AvatarDisplay/AvatarDisplay';
 import router from 'next/router';
 import { FC } from 'react';
 
-interface OutcomePanelProps {}
+interface OutcomePanelProps extends LayoutProps {}
 
-export const OutcomePanel: FC<OutcomePanelProps> = () => {
+export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
   const gameInfoContext = useGameInfoContext();
 
   if (process.browser) {
@@ -24,6 +24,9 @@ export const OutcomePanel: FC<OutcomePanelProps> = () => {
 
   return (
     <TwoColumnLayout
+      showProgressBar={props.showProgressBar}
+      showResetButton={props.showResetButton}
+      showSaveButton={props.showSaveButton}
       leftColumn={
         <Center>
           <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>

--- a/src/components/ui/Layout/Layout.tsx
+++ b/src/components/ui/Layout/Layout.tsx
@@ -2,7 +2,7 @@ import { Box } from '@chakra-ui/react';
 import { FC } from 'react';
 
 export interface LayoutProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   showProgressBar?: boolean;
   showResetButton?: boolean;
   showSaveButton?: boolean;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,23 @@
-import { AuthModal, Settings, SingleColumnLayout } from 'components/ui';
+import { AuthModal, Settings, SingleColumnLayout, useGameInfoContext } from 'components/ui';
 import React from 'react';
 
 const App = () => {
   const [authModelOpen, setAuthModalOpen] = React.useState(false);
+  const gameInfoContext = useGameInfoContext();
 
   return (
     <>
       <AuthModal isOpen={authModelOpen} onClose={() => setAuthModalOpen(false)}></AuthModal>
-      <SingleColumnLayout showProgressBar={false} showSaveButton={false} showResetButton={false}>
+      <SingleColumnLayout
+        showProgressBar={false}
+        showSaveButton={false}
+        showResetButton={false}
+        backgroundImage={
+          gameInfoContext.theme?.id == 'a5F4KpHzIkO1Re9iHmJjWA'
+            ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'
+            : '/corporate/background.jpg'
+        }
+      >
         <Settings />
       </SingleColumnLayout>
     </>

--- a/src/pages/outcome.tsx
+++ b/src/pages/outcome.tsx
@@ -5,8 +5,8 @@ interface OutcomePageProps {}
 
 const OutcomePage: React.FC<OutcomePageProps> = () => {
   return (
-    <Layout showProgressBar={false} showSaveButton={false}>
-      <OutcomePanel />
+    <Layout>
+      <OutcomePanel showProgressBar={false} showSaveButton={false} />
     </Layout>
   );
 };

--- a/src/pages/prompt.tsx
+++ b/src/pages/prompt.tsx
@@ -3,8 +3,8 @@ import { Layout } from 'components/ui';
 
 const PromptPage = () => {
   return (
-    <Layout showSaveButton={false}>
-      <PromptPanel showSaveButton={false} children={undefined} />
+    <Layout>
+      <PromptPanel showSaveButton={false} />
     </Layout>
   );
 };


### PR DESCRIPTION
This PR includes:

- Fix to remove progress bar + Save from outcome page, this was caused by a prop drills not passing through to the right component.
- Added a default theme background that will display on outcome and settings pages, once one is picked, but by default it will show the corporate if this is a first time use of the game.