### PR TITLE
Changes needed for Start Adventure custom text

### DIFF
--- a/src/GraphQL/Queries/Themes.gql
+++ b/src/GraphQL/Queries/Themes.gql
@@ -3,6 +3,7 @@ fragment Theme on GameTheme {
   name
   description
   chakraTheme
+  startButtonText
   characterImage {
     results {
       id

--- a/src/components/ui/Settings/Settings.tsx
+++ b/src/components/ui/Settings/Settings.tsx
@@ -98,9 +98,6 @@ export const Settings: FC<SettingsProps> = () => {
   };
   //#endregion
 
-  // console.log('avatar: ' + toggledAvatar);
-  // console.log('button: ' + toggledButton);
-
   return (
     <Container w="100%" maxWidth={'1136px'} rounded={'lg'} padding={10}>
       {loading ? (
@@ -132,7 +129,7 @@ export const Settings: FC<SettingsProps> = () => {
                   hidden={toggledAvatar == undefined || toggledButton == undefined}
                   onClick={() => handleStartGame()}
                 >
-                  Save Changes and Start Adventure
+                  {gameInfoContext.theme?.startButtonText ?? 'Save Changes and Start Adventure uh oh'}
                 </Button>
               </Center>
             </>

--- a/src/components/ui/Settings/Settings.tsx
+++ b/src/components/ui/Settings/Settings.tsx
@@ -129,7 +129,7 @@ export const Settings: FC<SettingsProps> = () => {
                   hidden={toggledAvatar == undefined || toggledButton == undefined}
                   onClick={() => handleStartGame()}
                 >
-                  {gameInfoContext.theme?.startButtonText ?? 'Save Changes and Start Adventure uh oh'}
+                  {gameInfoContext.theme?.startButtonText ?? 'Save Changes and Start Adventure'}
                 </Button>
               </Center>
             </>

--- a/src/models/ITheme.ts
+++ b/src/models/ITheme.ts
@@ -7,4 +7,5 @@ export interface ITheme {
   characterImage?: IResult<IImage[]>;
   avatarGallery?: IResult<IImage[]>;
   chakraTheme: string;
+  startButtonText: string;
 }


### PR DESCRIPTION
Not a whole lot to this one, just added the following:

- A field called "Start Button Text" to CH1 GameTheme content type and made it required.
- Updated the gql for Theme to pull this data from CH1
- Updated the model for Theme
- A check when pulled, that if not set, it'll default to what it was before this change was made "Save Changes and Start Adventure', even though with the field required it's unlikely anyone will ever see it.