### PR TITLE
Loading Animation fixes

### DIFF
--- a/src/components/ui/Layout/TwoColumnLayout.tsx
+++ b/src/components/ui/Layout/TwoColumnLayout.tsx
@@ -35,9 +35,7 @@ export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
       <Navigation showProgressBar={showProgressBar} showSaveButton={showSaveButton} showResetButton={showResetButton} />{' '}
       <Center>
         {loading ? (
-          <Box mt={10} mb={10}>
-            <Loading message="Loading Adventure Artifacts..." />
-          </Box>
+          <Loading message="Loading Adventure Artifacts..." />
         ) : (
           <Grid
             h="100%"

--- a/src/components/ui/Layout/TwoColumnLayout.tsx
+++ b/src/components/ui/Layout/TwoColumnLayout.tsx
@@ -16,40 +16,46 @@ interface TwoColumnLayoutProps {
 export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
   leftColumn,
   rightColumn,
-  backgroundImage = '/corporate/background.jpg',
+  backgroundImage = '',
   loading = false,
   showProgressBar = true,
   showResetButton = true,
   showSaveButton = true,
 }) => {
   return (
-    <Box
-      minH="100vh"
-      w="full"
-      backgroundImage={backgroundImage}
-      backgroundAttachment="fixed"
-      backgroundSize="cover"
-      backgroundRepeat="no-repeat"
-      paddingX={4}
-    >
-      <Navigation showProgressBar={showProgressBar} showSaveButton={showSaveButton} showResetButton={showResetButton} />{' '}
-      <Center>
-        {loading ? (
-          <Loading message="Loading Adventure Artifacts..." />
-        ) : (
-          <Grid
-            h="100%"
-            w={{ base: '1200px' }}
-            templateColumns={{ base: '1fr', md: '1fr 3fr' }}
-            gap={{ base: 0, lg: 5 }}
-            my={[2, 8]}
-            mx="auto"
-          >
-            <GridItem>{leftColumn}</GridItem>
-            <GridItem>{rightColumn}</GridItem>
-          </Grid>
-        )}
-      </Center>
-    </Box>
+    <>
+      {loading ? (
+        <Loading message="Loading Adventure Artifacts..." />
+      ) : (
+        <Box
+          minH="100vh"
+          w="full"
+          backgroundImage={backgroundImage}
+          backgroundAttachment="fixed"
+          backgroundSize="cover"
+          backgroundRepeat="no-repeat"
+          paddingX={4}
+        >
+          <Navigation
+            showProgressBar={showProgressBar}
+            showSaveButton={showSaveButton}
+            showResetButton={showResetButton}
+          />
+          <Center>
+            <Grid
+              h="100%"
+              w={{ base: '1200px' }}
+              templateColumns={{ base: '1fr', md: '1fr 3fr' }}
+              gap={{ base: 0, lg: 5 }}
+              my={[2, 8]}
+              mx="auto"
+            >
+              <GridItem>{leftColumn}</GridItem>
+              <GridItem>{rightColumn}</GridItem>
+            </Grid>
+          </Center>
+        </Box>
+      )}
+    </>
   );
 };

--- a/src/components/ui/Loading/Loading.tsx
+++ b/src/components/ui/Loading/Loading.tsx
@@ -1,4 +1,4 @@
-import { Center, Spinner, Stack, Text } from '@chakra-ui/react';
+import { Card, Spinner, Text, VStack } from '@chakra-ui/react';
 import { FC } from 'react';
 
 interface LoadingProps {
@@ -7,11 +7,11 @@ interface LoadingProps {
 
 export const Loading: FC<LoadingProps> = ({ message }) => {
   return (
-    <Stack style={{ margin: 'auto' }}>
-      <Spinner size="lg" style={{ margin: 'auto' }} />
-      <Center>
-        <Text w={500}>{message}</Text>
-      </Center>
-    </Stack>
+    <Card p="8" maxW="lg" opacity="0.75" align="center" variant="outline" my="20px" mx="auto">
+      <VStack spacing="5">
+        <Spinner size="xl" color="primary.500" thickness="4px" />
+        <Text>{message}</Text>
+      </VStack>
+    </Card>
   );
 };

--- a/src/components/ui/Settings/Settings.tsx
+++ b/src/components/ui/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Container, useBoolean } from '@chakra-ui/react';
+import { Button, Center, Container } from '@chakra-ui/react';
 import { useEngageTracker, useGameInfoContext } from 'components/Contexts';
 import { AvatarGallery, Loading, PersonaList, ThemeList } from 'components/ui';
 import { OutcomeService } from 'lib/OutcomeService';
@@ -24,14 +24,14 @@ export const Settings: FC<SettingsProps> = () => {
   const [avatars, setAvatars] = useState<IImage[] | undefined>();
   const [toggledButton, setToggledButton] = useState<string>();
   const [toggledAvatar, setToggledAvatar] = useState<IImage>();
-  const [loading, setLoading] = useBoolean(false);
+  const [loading, setLoading] = useState<Boolean>(false);
   const themeService = ThemeService();
   const personaService = PersonaService();
   const outcomeService = OutcomeService();
   //#endregion
 
   const initializeSettings = useCallback(async () => {
-    setLoading.on;
+    setLoading(true);
 
     const data = await themeService.GetAllThemes();
 
@@ -39,7 +39,7 @@ export const Settings: FC<SettingsProps> = () => {
       setThemes(data.results);
     }
 
-    setLoading.off;
+    setLoading(false);
   }, []);
 
   useEffect(() => {
@@ -50,7 +50,7 @@ export const Settings: FC<SettingsProps> = () => {
 
   //#region Functions
   const handleSettingChange = async (newTheme: string) => {
-    setLoading.on;
+    setLoading(true);
     await gameInfoContext.updateTheme(newTheme);
 
     await tracker.TrackEvent('THEME_CHANGE', { theme: newTheme });
@@ -76,7 +76,7 @@ export const Settings: FC<SettingsProps> = () => {
     }
 
     setShowCharacterOptions(true);
-    setLoading.off;
+    setLoading(false);
   };
 
   const handlePersonaChange = async (newPersona: string) => {
@@ -100,11 +100,9 @@ export const Settings: FC<SettingsProps> = () => {
 
   return (
     <Container w="100%" maxWidth={'1136px'} rounded={'lg'} padding={{ sm: 0, md: 10 }}>
-      {loading ? (
+      {loading == true ? (
         <>
-          <Center>
-            <Loading message="Loading settings..." />
-          </Center>
+          <Loading message="Loading settings..." />
         </>
       ) : (
         <>


### PR DESCRIPTION
This change fixes two bugs:

- Improve the UI of the Loading Animation
- Apply that animation across the app
- Update the logic to activate the loading animation when you select a theme, and then wait for persona/avatars to load.
- Tested in various mobile and desktop sizes.