### PR TITLE
Remove panel svg and reset margin/paddings

### DIFF
--- a/src/chakra/theme/fantasy/card.ts
+++ b/src/chakra/theme/fantasy/card.ts
@@ -5,11 +5,8 @@ const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpe
 
 const elevated = definePartsStyle({
   container: {
-    backdropFilter: { base: 'blur(24px)', md: 'none' },
-    backgroundColor: { base: '#00000070', md: 'transparent' },
-    backgroundImage: { base: 'none', md: '/fantasy/panel.svg' },
-    backgroundRepeat: 'no-repeat',
-    backgroundSize: 'contain',
+    backdropFilter: { base: 'blur(24px)' },
+    backgroundColor: { base: '#00000070' },
     fontFamily: 'var(--font-fondamento)',
     color: 'white',
     //opacity: { base: '0.2', xl: '1' },

--- a/src/chakra/theme/fantasy/container.ts
+++ b/src/chakra/theme/fantasy/container.ts
@@ -7,7 +7,6 @@ export const containerTheme = defineStyleConfig({
   variants: {
     questionPanel: {
       background: 'none',
-      backgroundImage: { base: '', md: '/fantasy/panel.svg' },
       backgroundColor: { base: '#313a46', md: 'transparent' },
       borderRadius: 'lg',
       opacity: { base: '0.8', xl: '1' },

--- a/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
@@ -10,7 +10,7 @@ interface IButtonGroupProps {
 export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent }) => {
   const theme = useTheme();
   return (
-    <Container mt={8} maxWidth={'100%'}>
+    <Container maxWidth={'100%'}>
       {options && (
         <>
           <SimpleGrid templateColumns={{ base: '1fr', sm: '1fr 1fr', lg: '1fr 1fr 1fr' }} spacing={2}>

--- a/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
+++ b/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardBody, CardFooter, Text } from '@chakra-ui/react';
+import { Card, CardBody, CardFooter, Text } from '@chakra-ui/react';
 import { ButtonGroup, MultiSelect } from 'components/Prompts';
 import { RichTextOutput } from 'components/ui';
 import { IAnswer, IOption, IPrompt } from 'models';
@@ -41,43 +41,25 @@ export const CurrentPrompt: FC<PromptProps> = ({ prompt, answerSelected }) => {
 
   return (
     <>
-      <Card
-        variant="elevated"
-        maxW={['100%', '90%']}
-        height={['auto', 'auto', '400px']}
-        margin={0}
-        shadow={'none'}
-        paddingTop={[0, 5]}
-        alignItems={'center'}
-      >
+      <Card variant="elevated" margin={0} padding={[0, 5]} alignItems={'center'}>
         <CardBody>
-          <Box
-            id="Box"
-            height={{ base: '250px', md: '150px', lg: '250px' }}
-            overflowY={'auto'}
-            marginLeft={{ base: '15px', md: '50px' }}
-            marginRight={{ base: '15px', md: '50px' }}
-            position={'relative'}
-            marginTop={{ base: '10px', md: '25px' }}
-            marginBottom={{ base: '15px', md: '0px' }}
-          >
-            {prompt?.bodyText && (
-              <Text>
-                <RichTextOutput content={prompt.bodyText} />
-              </Text>
-            )}
-          </Box>
+          {prompt?.bodyText && (
+            <Text textAlign={'center'} marginBottom={'15px'} minH={{ base: 0, xl: '350' }}>
+              <RichTextOutput content={prompt.bodyText} />
+            </Text>
+          )}
 
           <Text
             fontSize={['lg', '2xl']}
+            fontWeight={'bold'}
             textAlign={'center'}
-            paddingLeft={{ base: '15px', md: '50px' }}
-            paddingRight={{ base: '15px', md: '50px' }}
+            paddingLeft={{ base: '15px', md: '15px' }}
+            paddingRight={{ base: '15px', md: '15px' }}
           >
             {prompt?.text}
           </Text>
         </CardBody>
-        <CardFooter>
+        <CardFooter padding={'15px'}>
           {prompt?.options?.results != null && (
             <>
               {prompt?.optionType?.results[0].name === 'Checklist' && (

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -23,7 +23,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ options, multiSelectSubmit }
 
   return (
     <>
-      <Container mt={8} maxWidth={'100%'}>
+      <Container maxWidth={'100%'}>
         <VStack>
           <Text fontSize="2xl" variant={'answerInstruction'}>
             Select all that apply:


### PR DESCRIPTION
This PR removes the SVG used in the fantasy mode

- Removed background image in card variant
- Sets background color with opacity filter so color of background image will be used (fantasy mode)
- Reset margin/paddings in currentPrompt
- Set min-height for desktop mode (to prevent panel from constant resizing for every question)