### PR TITLE
background default + fix for if not set

### DIFF
--- a/src/components/Prompts/PromptPanel/PromptPanel.tsx
+++ b/src/components/Prompts/PromptPanel/PromptPanel.tsx
@@ -135,7 +135,15 @@ export const PromptPanel: FC<PromptPanelProps> = (props) => {
         </Center>
       }
       rightColumn={<CurrentPrompt prompt={currentPrompt} answerSelected={answerSelected} />}
-      backgroundImage={currentPrompt?.background?.results[0].fileUrl}
+      backgroundImage={
+        gameInfoContext.theme?.chakraTheme == 'corporate' ||
+        currentPrompt?.background?.results[0] === undefined ||
+        currentPrompt.background.results[0].fileUrl === ''
+          ? gameInfoContext.theme?.chakraTheme == 'corporate'
+            ? '/corporate/background.jpg'
+            : 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'
+          : currentPrompt?.background?.results[0].fileUrl
+      }
       loading={loading}
     ></TwoColumnLayout>
   );


### PR DESCRIPTION
This fixes two issues:

- Sets the default background for all corporate to the spiral default background.
- Fixes and displays the default background for the theme, if a prompt doesn't have a background set.