### PR TITLE
Added Feedback functionality

### DIFF
--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -33,6 +33,7 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
       showProgressBar={props.showProgressBar}
       showResetButton={props.showResetButton}
       showSaveButton={props.showSaveButton}
+      showFeedbackButton={props.showFeedbackButton}
       backgroundImage={
         gameInfoContext.theme?.chakraTheme == 'fantasy'
           ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'

--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -4,6 +4,7 @@ import { OutcomeGenerator } from 'components/Outcomes';
 import { PreviousAnswers } from 'components/Prompts';
 import { HexagonCollection, LayoutProps, TwoColumnLayout } from 'components/ui';
 import AvatarDisplay from 'components/ui/AvatarDisplay/AvatarDisplay';
+import { FeedbackModal } from 'components/ui/FeedbackModal/FeedbackModal';
 import router from 'next/router';
 import { FC, useEffect } from 'react';
 
@@ -29,34 +30,37 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
   }, []);
 
   return (
-    <TwoColumnLayout
-      showProgressBar={props.showProgressBar}
-      showResetButton={props.showResetButton}
-      showSaveButton={props.showSaveButton}
-      showFeedbackButton={props.showFeedbackButton}
-      backgroundImage={
-        gameInfoContext.theme?.chakraTheme == 'fantasy'
-          ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'
-          : '/corporate/background.jpg'
-      }
-      leftColumn={
-        <Center>
-          <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>
-            {gameInfoContext.avatar?.fileUrl !== undefined && gameInfoContext?.persona !== undefined && (
-              <AvatarDisplay fileUrl={gameInfoContext.avatar?.fileUrl} name={gameInfoContext?.persona.name} />
-            )}
-            <HexagonCollection />
-          </Stack>
-        </Center>
-      }
-      rightColumn={
-        <Card w="100%" mt={8} mb={4} p={8} display="flex" alignItems="center" flexDirection="column">
-          <Stack>
-            <OutcomeGenerator />
-            <PreviousAnswers />
-          </Stack>
-        </Card>
-      }
-    ></TwoColumnLayout>
+    <>
+      <FeedbackModal />
+      <TwoColumnLayout
+        showProgressBar={props.showProgressBar}
+        showResetButton={props.showResetButton}
+        showSaveButton={props.showSaveButton}
+        showFeedbackButton={props.showFeedbackButton}
+        backgroundImage={
+          gameInfoContext.theme?.chakraTheme == 'fantasy'
+            ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'
+            : '/corporate/background.jpg'
+        }
+        leftColumn={
+          <Center>
+            <Stack direction={{ base: 'row', lg: 'column' }} gap={{ base: 20, lg: 0 }}>
+              {gameInfoContext.avatar?.fileUrl !== undefined && gameInfoContext?.persona !== undefined && (
+                <AvatarDisplay fileUrl={gameInfoContext.avatar?.fileUrl} name={gameInfoContext?.persona.name} />
+              )}
+              <HexagonCollection />
+            </Stack>
+          </Center>
+        }
+        rightColumn={
+          <Card w="100%" mt={8} mb={4} p={8} display="flex" alignItems="center" flexDirection="column">
+            <Stack>
+              <OutcomeGenerator />
+              <PreviousAnswers />
+            </Stack>
+          </Card>
+        }
+      ></TwoColumnLayout>
+    </>
   );
 };

--- a/src/components/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/ui/FeedbackModal/FeedbackModal.tsx
@@ -1,0 +1,60 @@
+import {
+  Button,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  Tooltip,
+} from '@chakra-ui/react';
+import { FC, useEffect, useState } from 'react';
+import { MdOutlineMarkChatRead } from 'react-icons/md';
+
+interface FeedbackModalProps {}
+
+export const FeedbackModal: FC<FeedbackModalProps> = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    setTimeout(function () {
+      setIsOpen(true);
+    }, 5000);
+  }, []);
+
+  const onClose = () => setIsOpen(false);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(5px)" />
+      <ModalContent>
+        <ModalHeader>Feedback Request</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text>
+            Thank you for trying our Migration adventure, we would greatly appreciate any feedback (positive or
+            negative)!
+          </Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <Tooltip label="Give Feedback" aria-label="Give Feedback">
+            <Link href="https://forms.office.com/e/Mc6wczVqgh" isExternal>
+              <Button
+                rightIcon={<MdOutlineMarkChatRead size={24} />}
+                colorScheme="primary"
+                variant="solid"
+                aria-label={'Give Feedback'}
+              >
+                Give Feedback
+              </Button>
+            </Link>
+          </Tooltip>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/src/components/ui/FeedbackModal/FeedbackModal.tsx
+++ b/src/components/ui/FeedbackModal/FeedbackModal.tsx
@@ -28,7 +28,7 @@ export const FeedbackModal: FC<FeedbackModalProps> = () => {
   const onClose = () => setIsOpen(false);
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+    <Modal isOpen={isOpen} onClose={onClose} size={{ base: 'xs', md: 'md' }}>
       <ModalOverlay bg="blackAlpha.300" backdropFilter="blur(5px)" />
       <ModalContent>
         <ModalHeader>Feedback Request</ModalHeader>

--- a/src/components/ui/Layout/Layout.tsx
+++ b/src/components/ui/Layout/Layout.tsx
@@ -6,6 +6,7 @@ export interface LayoutProps {
   showProgressBar?: boolean;
   showResetButton?: boolean;
   showSaveButton?: boolean;
+  showFeedbackButton?: boolean;
 }
 
 export const Layout: FC<LayoutProps> = ({ children }) => {

--- a/src/components/ui/Layout/SingleColumnLayout.tsx
+++ b/src/components/ui/Layout/SingleColumnLayout.tsx
@@ -10,6 +10,7 @@ interface SingleColumnLayoutProps {
   showProgressBar?: boolean;
   showResetButton?: boolean;
   showSaveButton?: boolean;
+  showFeedbackButton?: boolean;
 }
 
 export const SingleColumnLayout: FC<SingleColumnLayoutProps> = ({
@@ -19,6 +20,7 @@ export const SingleColumnLayout: FC<SingleColumnLayoutProps> = ({
   showProgressBar = true,
   showResetButton = true,
   showSaveButton = true,
+  showFeedbackButton = true,
 }) => {
   return (
     <Box
@@ -30,7 +32,12 @@ export const SingleColumnLayout: FC<SingleColumnLayoutProps> = ({
       backgroundRepeat="no-repeat"
       paddingX={4}
     >
-      <Navigation showProgressBar={showProgressBar} showSaveButton={showSaveButton} showResetButton={showResetButton} />
+      <Navigation
+        showProgressBar={showProgressBar}
+        showSaveButton={showSaveButton}
+        showResetButton={showResetButton}
+        showFeedbackButton={showFeedbackButton}
+      />
 
       <Center>
         {loading ? (

--- a/src/components/ui/Layout/TwoColumnLayout.tsx
+++ b/src/components/ui/Layout/TwoColumnLayout.tsx
@@ -11,6 +11,7 @@ interface TwoColumnLayoutProps {
   showProgressBar?: boolean;
   showResetButton?: boolean;
   showSaveButton?: boolean;
+  showFeedbackButton?: boolean;
 }
 
 export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
@@ -21,6 +22,7 @@ export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
   showProgressBar = true,
   showResetButton = true,
   showSaveButton = true,
+  showFeedbackButton = true,
 }) => {
   return (
     <>
@@ -40,6 +42,7 @@ export const TwoColumnLayout: FC<TwoColumnLayoutProps> = ({
             showProgressBar={showProgressBar}
             showSaveButton={showSaveButton}
             showResetButton={showResetButton}
+            showFeedbackButton={showFeedbackButton}
           />
           <Center>
             <Grid

--- a/src/components/ui/Navigation/Navigation.tsx
+++ b/src/components/ui/Navigation/Navigation.tsx
@@ -39,7 +39,17 @@ export const Navigation: FC<NavigationProps> = ({
             <Box alignContent="right">
               <HStack>
                 {showFeedbackButton && (
-                  <Show above={gameInfoContext.theme?.chakraTheme == 'fantasy' ? 'lg' : 'md'}>
+                  <Show
+                    above={
+                      gameInfoContext.theme?.chakraTheme == 'fantasy'
+                        ? showProgressBar && showResetButton
+                          ? 'lg'
+                          : 'sm'
+                        : showProgressBar && showResetButton
+                        ? 'md'
+                        : 'sm'
+                    }
+                  >
                     <Tooltip label="Leave Feedback" aria-label="Leave Feedback">
                       <Link href="https://forms.office.com/e/Mc6wczVqgh" isExternal>
                         <Button

--- a/src/components/ui/Navigation/Navigation.tsx
+++ b/src/components/ui/Navigation/Navigation.tsx
@@ -1,9 +1,9 @@
-import { Box, HStack, IconButton, Tooltip } from '@chakra-ui/react';
+import { Box, Button, HStack, IconButton, Link, Show, Tooltip } from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import Image from 'next/image';
 import Router from 'next/router';
 import { FC } from 'react';
-import { MdCached, MdSave } from 'react-icons/md';
+import { MdCached, MdOutlineMarkChatRead, MdSave } from 'react-icons/md';
 import { InfoModal } from '../InfoModal/InfoModal';
 import { ProgressTracker } from '../ProgressTracker/ProgressTracker';
 
@@ -31,12 +31,26 @@ export const Navigation: FC<NavigationProps> = ({
               <Image src="/corporate/logo-sitecore.svg" alt="Sitecore Logo" width={200} height={50} />
             </Box>
             {showProgressBar && (
-              <Box width="300px">
+              <Box width="300px" px="4">
                 <ProgressTracker />
               </Box>
             )}
-            <Box alignContent="right" width="100px">
-              <HStack spacing={2}>
+            <Box alignContent="right">
+              <HStack>
+                <Show above={gameInfoContext.theme?.chakraTheme == 'fantasy' ? 'lg' : 'md'}>
+                  <Tooltip label="Leave Feedback" aria-label="Leave Feedback">
+                    <Link href="https://forms.office.com/e/Mc6wczVqgh" isExternal>
+                      <Button
+                        rightIcon={<MdOutlineMarkChatRead size={24} />}
+                        colorScheme="neutral"
+                        variant="solid"
+                        aria-label={''}
+                      >
+                        Give Feedback
+                      </Button>
+                    </Link>
+                  </Tooltip>
+                </Show>
                 {showSaveButton && (
                   <Tooltip label="Save Your Result" aria-label="Save Your Result">
                     <IconButton
@@ -61,6 +75,7 @@ export const Navigation: FC<NavigationProps> = ({
                     ></IconButton>
                   </Tooltip>
                 )}
+
                 <InfoModal />
               </HStack>
             </Box>

--- a/src/components/ui/Navigation/Navigation.tsx
+++ b/src/components/ui/Navigation/Navigation.tsx
@@ -12,13 +12,14 @@ interface NavigationProps {
   showResetButton?: boolean;
   showSaveButton?: boolean;
   showSettingsButton?: boolean;
+  showFeedbackButton?: boolean;
 }
 
 export const Navigation: FC<NavigationProps> = ({
   showProgressBar = true,
   showResetButton = true,
   showSaveButton = true,
-  showSettingsButton = true,
+  showFeedbackButton = true,
 }) => {
   const gameInfoContext = useGameInfoContext();
 
@@ -37,20 +38,23 @@ export const Navigation: FC<NavigationProps> = ({
             )}
             <Box alignContent="right">
               <HStack>
-                <Show above={gameInfoContext.theme?.chakraTheme == 'fantasy' ? 'lg' : 'md'}>
-                  <Tooltip label="Leave Feedback" aria-label="Leave Feedback">
-                    <Link href="https://forms.office.com/e/Mc6wczVqgh" isExternal>
-                      <Button
-                        rightIcon={<MdOutlineMarkChatRead size={24} />}
-                        colorScheme="neutral"
-                        variant="solid"
-                        aria-label={''}
-                      >
-                        Give Feedback
-                      </Button>
-                    </Link>
-                  </Tooltip>
-                </Show>
+                {showFeedbackButton && (
+                  <Show above={gameInfoContext.theme?.chakraTheme == 'fantasy' ? 'lg' : 'md'}>
+                    <Tooltip label="Leave Feedback" aria-label="Leave Feedback">
+                      <Link href="https://forms.office.com/e/Mc6wczVqgh" isExternal>
+                        <Button
+                          rightIcon={<MdOutlineMarkChatRead size={24} />}
+                          colorScheme="neutral"
+                          variant="solid"
+                          aria-label={''}
+                        >
+                          Give Feedback
+                        </Button>
+                      </Link>
+                    </Tooltip>
+                  </Show>
+                )}
+
                 {showSaveButton && (
                   <Tooltip label="Save Your Result" aria-label="Save Your Result">
                     <IconButton

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ const App = () => {
         showProgressBar={false}
         showSaveButton={false}
         showResetButton={false}
+        showFeedbackButton={true}
         backgroundImage={
           gameInfoContext.theme?.chakraTheme == 'fantasy'
             ? 'https://mms-delivery.sitecorecloud.io/api/media/v2/delivery/df4c80ea-db67-49f8-bcd3-08daadeee4f5/182bc6d196aa465cbf9b614ff2883eb4'

--- a/src/pages/outcome.tsx
+++ b/src/pages/outcome.tsx
@@ -6,7 +6,7 @@ interface OutcomePageProps {}
 const OutcomePage: React.FC<OutcomePageProps> = () => {
   return (
     <Layout>
-      <OutcomePanel showProgressBar={false} showSaveButton={false} />
+      <OutcomePanel showProgressBar={false} showSaveButton={false} showFeedbackButton={false} />
     </Layout>
   );
 };

--- a/src/pages/prompt.tsx
+++ b/src/pages/prompt.tsx
@@ -4,7 +4,7 @@ import { Layout } from 'components/ui';
 const PromptPage = () => {
   return (
     <Layout>
-      <PromptPanel showSaveButton={false} />
+      <PromptPanel showSaveButton={false} showFeedbackButton={true} />
     </Layout>
   );
 };


### PR DESCRIPTION
I'm sure there will be lots of comments here:

- Feedback pops up on Outcome page after 5 seconds (we can change this value, should it be longer, shorter, or not exist at all)?
- How about the text here in the modal?  Does it need work? Suggestions welcome.
- Feedback button in navigation does not display on the outcome page (since we have an outcome popup) (Should it or should it still show up anyway)
- The feedback button shows up only in larger screen sizes everywhere else.  In fantasy, because the button is larger, we have to only show at the largest screen sizes.
- Feedback button opens new tab/window with form in it.
- Is there anywhere you think the button or modal should be or shouldn't be?