### PR TITLE
Added additional logging of answers for CDP/GA

### DIFF
--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -4,6 +4,7 @@ import { OutcomeGenerator } from 'components/Outcomes';
 import { PreviousAnswers } from 'components/Prompts';
 import { HexagonCollection, LayoutProps, TwoColumnLayout } from 'components/ui';
 import AvatarDisplay from 'components/ui/AvatarDisplay/AvatarDisplay';
+import * as GTag from 'lib/GTag';
 import router from 'next/router';
 import { FC, useEffect } from 'react';
 
@@ -25,7 +26,14 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
   }
 
   useEffect(() => {
-    tracker.TrackPageView({ page: '/outcome', channel: 'WEB', language: 'EN', currency: 'USD' });
+    tracker.TrackPageView(
+      { page: '/outcome', channel: 'WEB', language: 'EN', currency: 'USD' },
+      {
+        answers: JSON.stringify(gameInfoContext.answers),
+      }
+    );
+
+    GTag.event('outcome_answers', 'Answers', JSON.stringify(gameInfoContext.answers));
   }, []);
 
   return (

--- a/src/components/ui/InfoModal/InfoModal.tsx
+++ b/src/components/ui/InfoModal/InfoModal.tsx
@@ -53,7 +53,10 @@ export const InfoModal: FC<InfoModalProps> = () => {
           <ModalBody>
             <Stack divider={<StackDivider />} spacing="4">
               <Box>
-                <Text>This application is powered by Sitecore Content Hub ONE to store media and content.</Text>
+                <Text>
+                  This application is powered by Sitecore Content Hub ONE to store media and content. The application is
+                  powered by Sitecore CDP and Personalize for capturing user interactions and events.
+                </Text>
               </Box>
               <Box>
                 <Text>


### PR DESCRIPTION
Added to GA/CDP the tracking of outcome answers (answers that got to this outcome).  Can't really see the data locally currently, since both GA/CDP take a while to process event data like this, but not seeing any errors and will make another change if needed after this PR is approved, if needed.

This also includes the update to About Info Modal, to include a reference to CDP/Personalize.  Will keep it simple for now.