### PR TITLE
90 add community articles

### DIFF
--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -221,6 +221,12 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
           link="https://jackspektor.medium.com/estimating-sitecore-xp-to-xm-cloud-upgrade-what-challenges-lies-ahead-226d1c36b8e"
           title="Estimating Sitecore XP to XM Cloud upgrade — what challenges lies ahead? (Jack Spektor)"
         />
+        <ConditionalResponse condition={!outcomeConditions.isFullyHeadless()}>
+          <LinkCard
+            link="https://blogs.perficient.com/2022/11/28/a-practical-roadmap-for-existing-sitecore-customers-to-move-to-xm-cloud/"
+            title="A Practical Roadmap for Existing Sitecore Customers to Move To XM Cloud (David San Filippo)"
+          />
+        </ConditionalResponse>
       </SimpleGrid>
       <ConditionalResponse condition={outcomeConditions.existingFrameworks.netcore}>
         <Heading size="lg" mb={2}>

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -191,6 +191,10 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
         <RichTextOutput content={gameInfoContext.outcome.xmFeaturesIntro} />
       </Text>
       <SimpleGrid columns={3} minChildWidth="250px" spacing="md">
+        {/*Rob Habraken SUGCON video*/}
+        <YouTubeVideoDisplay videoId="vLAfx7dps_Q" />
+
+        {/*Start articles*/}
         <ConditionalResponse
           condition={
             outcomeConditions.isXM &&

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -5,7 +5,7 @@ import { LinkCard, RichTextOutput, YouTubeVideoDisplay } from 'components/ui';
 import { ExperienceEdgeOption, OutcomeConditions, TargetProduct } from 'models/OutcomeConditions';
 import { FC } from 'react';
 
-interface OutcomeGeneratorProps { }
+interface OutcomeGeneratorProps {}
 
 export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
   const gameInfoContext = useGameInfoContext();
@@ -211,16 +211,17 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
             title="XM Cloud Introduction GitHub Repo: Shows Next.js and .NET headless sites migrated from XM 10.2"
           />
         </ConditionalResponse>
-        <ConditionalResponse
-          condition={outcomeConditions.desiredFrameworks.nextjs}
-        >
+        <ConditionalResponse condition={outcomeConditions.desiredFrameworks.nextjs}>
           <LinkCard
             link="https://thetombomb.com/posts/nextjs-hosting-alternatives"
-          title="Beyond Vercel: Hosting Alternatives for Next.js"
+            title="Beyond Vercel: Hosting Alternatives for Next.js"
+          />
+        </ConditionalResponse>
+        <LinkCard
+          link="https://jackspektor.medium.com/estimating-sitecore-xp-to-xm-cloud-upgrade-what-challenges-lies-ahead-226d1c36b8e"
+          title="Estimating Sitecore XP to XM Cloud upgrade — what challenges lies ahead? (Jack Spektor)"
         />
-      </ConditionalResponse>
-
-    </SimpleGrid >
+      </SimpleGrid>
       <ConditionalResponse condition={outcomeConditions.existingFrameworks.netcore}>
         <Heading size="lg" mb={2}>
           {gameInfoContext.outcome.aspnetHeadlessTitle}

--- a/src/lib/GameContextParser.ts
+++ b/src/lib/GameContextParser.ts
@@ -127,7 +127,14 @@ export class GameContextParser {
       (x: IAnswer) => x.promptQuestionId == PromptMappings.existingFramework
     );
     if (existingFrameworkOptions != undefined) {
+      outcomeConditions.existingFrameworks.angular = existingFrameworkOptions.value.includes('angular');
+      outcomeConditions.existingFrameworks.mvc = existingFrameworkOptions.value.includes('mvc');
       outcomeConditions.existingFrameworks.netcore = existingFrameworkOptions.value.includes('netcore');
+      outcomeConditions.existingFrameworks.nextjs = existingFrameworkOptions.value.includes('nextjs');
+      outcomeConditions.existingFrameworks.sxa = existingFrameworkOptions.value.includes('sxa');
+      outcomeConditions.existingFrameworks.vue = existingFrameworkOptions.value.includes('vuejs');
+      outcomeConditions.existingFrameworks.webforms = existingFrameworkOptions.value.includes('webforms');
+      outcomeConditions.existingFrameworks.xslt = existingFrameworkOptions.value.includes('xslt');
     }
   }
 

--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -42,7 +42,15 @@ export interface IDesiredFrameworks {
 }
 
 export interface IExistingFrameworks {
+  angular: boolean;
+  mvc: boolean;
   netcore: boolean;
+  nextjs: boolean;
+  react: boolean;
+  sxa: boolean;
+  vue: boolean;
+  webforms: boolean;
+  xslt: boolean;
 }
 
 export interface ISecuredPages {
@@ -129,7 +137,17 @@ export class OutcomeConditions {
       morethan90days: false,
     };
     this.desiredFrameworks = { netcore: false, nextjs: false };
-    this.existingFrameworks = { netcore: false };
+    this.existingFrameworks = {
+      angular: false,
+      mvc: false,
+      netcore: false,
+      nextjs: false,
+      react: false,
+      sxa: false,
+      vue: false,
+      webforms: false,
+      xslt: false,
+    };
     this.securedPages = { securityloginrequired: false };
     this.experienceEdge = ExperienceEdgeOption.no;
     this.siteSearchUsed = { indexSearch: false };
@@ -161,6 +179,20 @@ export class OutcomeConditions {
       this.xpFeaturesUsed.externalDataSystems ||
       this.xpFeaturesUsed.identityResolution ||
       this.xpFeaturesUsed.patternCards
+    );
+  }
+
+  /**
+   * Checks current frameworks to ensure that there are no non-Headless frameworks selected.
+   * If even a single non-Headless framework is selected, there is front-end migration work
+   * required (such as MVC to Next.js)
+   */
+  isFullyHeadless(): boolean {
+    return (
+      !this.existingFrameworks.mvc &&
+      !this.existingFrameworks.sxa &&
+      !this.existingFrameworks.webforms &&
+      !this.existingFrameworks.xslt
     );
   }
 


### PR DESCRIPTION
Fixes #90 

Added two articles and a video, as defined in #90 . The video and the Spektor article show for all outcomes, and the San Filippo article only displays if the user specifies that they currently have a non-headless framework for their implementation.