### PR TITLE
Overriding Sitecore Theme isActive with a darker color

### DIFF
--- a/src/chakra/theme/corporate/button.ts
+++ b/src/chakra/theme/corporate/button.ts
@@ -1,0 +1,13 @@
+export const buttonOverride = {
+  components: {
+    Button: {
+      variants: {
+        solid: {
+          _active: {
+            background: 'primary.900',
+          },
+        },
+      }
+    }
+  }
+}

--- a/src/components/ui/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/src/components/ui/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,6 +1,7 @@
 import { ChakraProvider, ChakraTheme, extendTheme } from '@chakra-ui/react';
 import { withProse } from '@nikolovlazar/chakra-ui-prose';
 import sitecoreTheme from '@sitecore/blok-theme';
+import { buttonOverride } from 'chakra/theme/corporate/button';
 import fantasyTheme from 'chakra/theme/fantasy/theme';
 import { useGameInfoContext } from 'components/Contexts';
 import { FC, useEffect, useState } from 'react';
@@ -28,7 +29,7 @@ export const ThemeSwitcher: FC<ThemeSwitcherProps> = ({ children }) => {
         )
       );
     } else if (gameInfoContext?.theme?.chakraTheme == 'corporate') {
-      setTheme(extendTheme(sitecoreTheme, withProse()));
+      setTheme(extendTheme(sitecoreTheme, buttonOverride, withProse()));
     }
   }, [gameInfoContext?.theme]);
 


### PR DESCRIPTION
Previously it was difficult to tell in the Persona list and Multi Select which options where active. 

Before: 
![image](https://github.com/Sitecore/Sitecore-Migration-Game/assets/24610108/b3947dfd-bc2c-4ea9-9e01-a73c7af09470)

With Change:
![image](https://github.com/Sitecore/Sitecore-Migration-Game/assets/24610108/409f3013-fb5f-4864-ad1d-ecadbf8fb9e9)


I attempted to limit the scope to just the solid button variants which is what is being used on persona list and multi select. This has also been organized into the chakra/theme folder so if we need future overrrides on buttons or other corporate components they can go there as well. 