### PR TITLE
97 add product recommendation reasons

### DIFF
--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -14,8 +14,8 @@ describe('Outcome Page', () => {
     cy.get('[value="yesexperienceedge"]').click();
     cy.wait(5000);
     cy.get('.chakra-modal__close-btn').click();
-    cy.get('ul#required-products').should('exist').find('li').should('have.length', 1);
-    cy.get('ul#required-products li').eq(0).should('contain', 'XM Cloud');
+    cy.get('#required-products').should('exist').children().should('have.length', 1);
+    cy.get('#required-products').children().should('contain', 'XM Cloud');
   });
 
   it('multiple required products', () => {
@@ -42,18 +42,16 @@ describe('Outcome Page', () => {
     cy.get('[value="historicalpersonalize90"]').click();
     cy.get('[value="search-index"]').click();
     cy.get('[value="unicorn"]').click();
-    // cy.get('.css-18udl74').click();
-    // cy.get('.css-e3ognv').click();
     cy.get('[value="netcore"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();
     cy.get('[value="noexperienceedge"]').click();
     cy.wait(5000);
     cy.get('.chakra-modal__close-btn').click();
-    cy.get('ul#required-products').should('exist').find('li').should('have.length', 5);
-    cy.get('ul#required-products li').eq(0).should('contain', 'XM Cloud');
-    cy.get('ul#required-products li').eq(1).should('contain', 'Search');
-    cy.get('ul#required-products li').eq(2).should('contain', 'Personalize');
-    cy.get('ul#required-products li').eq(3).should('contain', 'CDP');
-    cy.get('ul#required-products li').eq(4).should('contain', 'Send');
+    cy.get('#required-products').should('exist').children().should('have.length', 5);
+    cy.get('#required-products').children().should('contain', 'XM Cloud');
+    cy.get('#required-products').children().should('contain', 'Search');
+    cy.get('#required-products').children().should('contain', 'Personalize');
+    cy.get('#required-products').children().should('contain', 'CDP');
+    cy.get('#required-products').children().should('contain', 'Send');
   });
 });

--- a/src/GraphQL/Queries/Outcome.gql
+++ b/src/GraphQL/Queries/Outcome.gql
@@ -11,6 +11,14 @@ fragment OutcomeDetails on GameOutcome {
   }
   title
   productsIntro
+  outcomeReasons {
+    results {
+      ... on GameOutcomeReason {
+        product
+        reason
+      }
+    }
+  }
   videoTitle
   videoIntro
   videoid

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -5,7 +5,7 @@ import { LinkCard, RichTextOutput, YouTubeVideoDisplay } from 'components/ui';
 import { ExperienceEdgeOption, OutcomeConditions, TargetProduct } from 'models/OutcomeConditions';
 import { FC } from 'react';
 
-interface OutcomeGeneratorProps { }
+interface OutcomeGeneratorProps {}
 
 export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
   const gameInfoContext = useGameInfoContext();
@@ -32,9 +32,20 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
         <RichTextOutput content={gameInfoContext.outcome.productsIntro} />
       </Text>
       {requiredProducts && requiredProducts.length > 0 && (
-        <List size="lg" pb="20px" id='required-products'>
+        <List size="lg" pb="20px" id="required-products">
           {requiredProducts.map((product: TargetProduct) => (
-            <ListItem>{product}</ListItem>
+            <ListItem>
+              <Heading size="md" mb={2}>
+                {product}
+              </Heading>
+              {gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product) != undefined ? (
+                <RichTextOutput
+                  content={gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product)?.reason!}
+                />
+              ) : (
+                <></>
+              )}
+            </ListItem>
           ))}
         </List>
       )}
@@ -211,16 +222,13 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
             title="XM Cloud Introduction GitHub Repo: Shows Next.js and .NET headless sites migrated from XM 10.2"
           />
         </ConditionalResponse>
-        <ConditionalResponse
-          condition={outcomeConditions.desiredFrameworks.nextjs}
-        >
+        <ConditionalResponse condition={outcomeConditions.desiredFrameworks.nextjs}>
           <LinkCard
             link="https://thetombomb.com/posts/nextjs-hosting-alternatives"
-          title="Beyond Vercel: Hosting Alternatives for Next.js"
-        />
-      </ConditionalResponse>
-
-    </SimpleGrid >
+            title="Beyond Vercel: Hosting Alternatives for Next.js"
+          />
+        </ConditionalResponse>
+      </SimpleGrid>
       <ConditionalResponse condition={outcomeConditions.existingFrameworks.netcore}>
         <Heading size="lg" mb={2}>
           {gameInfoContext.outcome.aspnetHeadlessTitle}

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -1,4 +1,14 @@
-import { Heading, List, ListItem, SimpleGrid, Text } from '@chakra-ui/react';
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Heading,
+  SimpleGrid,
+  Text,
+} from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import { ConditionalResponse } from 'components/Outcomes';
 import { LinkCard, RichTextOutput, YouTubeVideoDisplay } from 'components/ui';
@@ -32,22 +42,31 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
         <RichTextOutput content={gameInfoContext.outcome.productsIntro} />
       </Text>
       {requiredProducts && requiredProducts.length > 0 && (
-        <List size="lg" pb="20px" id="required-products">
+        <Accordion size="lg" pb="20px" id="required-products" allowMultiple>
           {requiredProducts.map((product: TargetProduct) => (
-            <ListItem>
-              <Heading size="md" mb={2}>
-                {product}
-              </Heading>
-              {gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product) != undefined ? (
-                <RichTextOutput
-                  content={gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product)?.reason!}
-                />
-              ) : (
-                <></>
-              )}
-            </ListItem>
+            <AccordionItem>
+              <AccordionButton>
+                <Box>
+                  <Heading size="md" mb={2}>
+                    {product}
+                  </Heading>
+                </Box>
+                <AccordionIcon />
+              </AccordionButton>
+              <AccordionPanel>
+                {gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product) != undefined ? (
+                  <RichTextOutput
+                    content={
+                      gameInfoContext.outcome?.outcomeReasons.results.find((r) => r.product === product)?.reason!
+                    }
+                  />
+                ) : (
+                  <></>
+                )}
+              </AccordionPanel>
+            </AccordionItem>
           ))}
-        </List>
+        </Accordion>
       )}
 
       <Heading size="lg" mb={2}>

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -46,7 +46,7 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
           {requiredProducts.map((product: TargetProduct) => (
             <AccordionItem>
               <AccordionButton>
-                <Box>
+                <Box as="span" flex="1" textAlign="left">
                   <Heading size="md" mb={2}>
                     {product}
                   </Heading>

--- a/src/models/IOutcome.ts
+++ b/src/models/IOutcome.ts
@@ -1,11 +1,12 @@
 import { JSONContent } from '@tiptap/core';
-import { IResult, ITheme } from 'models';
+import { IOutcomeReason, IResult, ITheme } from 'models';
 
 export interface IOutcome {
   id: string;
   name: string;
   title: string;
   productsIntro: JSONContent;
+  outcomeReasons: IResult<IOutcomeReason[]>;
   videoTitle: string;
   videoIntro: JSONContent;
   videoid: string;

--- a/src/models/IOutcomeReason.ts
+++ b/src/models/IOutcomeReason.ts
@@ -1,4 +1,6 @@
+import { JSONContent } from '@tiptap/core';
+
 export interface IOutcomeReason {
   product: string;
-  reason: string;
+  reason: JSONContent;
 }

--- a/src/models/IOutcomeReason.ts
+++ b/src/models/IOutcomeReason.ts
@@ -1,0 +1,4 @@
+export interface IOutcomeReason {
+  product: string;
+  reason: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,6 +3,7 @@ export * from './IImage';
 export * from './IOption';
 export * from './IOptionType';
 export * from './IOutcome';
+export * from './IOutcomeReason';
 export * from './IPersona';
 export * from './IPrompt';
 export * from './IResult';


### PR DESCRIPTION
Adds new queries to pull in "outcome reasons" from Content Hub ONE. Each outcome reason has a text which explains why a particular product is needed for the migration. The Outcome Generator will display reasons for the products that are recommended.

Fixes #97 