### PR TITLE
Added tracking of external link click for guides

### DIFF
--- a/src/components/ui/LinkCard/LinkCard.tsx
+++ b/src/components/ui/LinkCard/LinkCard.tsx
@@ -1,4 +1,6 @@
 import { Button, Card, CardBody, CardHeader, Heading, Text } from '@chakra-ui/react';
+import { useEngageTracker } from 'components/Contexts';
+import * as GTag from 'lib/GTag';
 import Link from 'next/link';
 import { FC } from 'react';
 import { FiExternalLink } from 'react-icons/fi';
@@ -10,6 +12,14 @@ interface LinkCardProps {
 }
 
 export const LinkCard: FC<LinkCardProps> = ({ ...props }) => {
+  const tracker = useEngageTracker();
+
+  const handleExternalLinkClick = async (e: any) => {
+    await tracker?.TrackEvent('external_link_click', { url: props.link });
+
+    GTag.event('external_link_click', 'External Link', props.link);
+  };
+
   return (
     <Card mr={3} mb={3} variant={'outlineRaised'}>
       <CardHeader>
@@ -17,7 +27,12 @@ export const LinkCard: FC<LinkCardProps> = ({ ...props }) => {
       </CardHeader>
       <CardBody>
         {props.description && <Text>{props.description}</Text>}
-        <Button leftIcon={<FiExternalLink />} variant={'solid'} colorScheme="neutral">
+        <Button
+          leftIcon={<FiExternalLink />}
+          variant={'solid'}
+          colorScheme="neutral"
+          onClick={(e) => handleExternalLinkClick(e)}
+        >
           <Link href={props.link} target="_blank" rel="noopener noreferrer">
             Learn More
           </Link>


### PR DESCRIPTION
Essentially added the mechanism to track clicks on external links to both Google Analytics and CDP.  I've confirmed this works with CDP, however not seeing the data in Analytics yet, but that's not entirely surprising since it does seem to have a delay.

Didn't need to block the ui, since all the guides open in a new window. 