### PR TITLE
Removing feedback modal pop up

### DIFF
--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -12,8 +12,6 @@ describe('Outcome Page', () => {
     cy.get('[value="vuejs"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();
     cy.get('[value="yesexperienceedge"]').click();
-    cy.wait(5000);
-    cy.get('.chakra-modal__close-btn').click();
     cy.get('#required-products').should('exist').children().should('have.length', 1);
     cy.get('#required-products').children().should('contain', 'XM Cloud');
   });
@@ -45,8 +43,6 @@ describe('Outcome Page', () => {
     cy.get('[value="netcore"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();
     cy.get('[value="noexperienceedge"]').click();
-    cy.wait(5000);
-    cy.get('.chakra-modal__close-btn').click();
     cy.get('#required-products').should('exist').children().should('have.length', 5);
     cy.get('#required-products').children().should('contain', 'XM Cloud');
     cy.get('#required-products').children().should('contain', 'Search');

--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -39,7 +39,6 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
 
   return (
     <>
-      <FeedbackModal />
       <TwoColumnLayout
         showProgressBar={props.showProgressBar}
         showResetButton={props.showResetButton}

--- a/src/pages/outcome.tsx
+++ b/src/pages/outcome.tsx
@@ -6,7 +6,7 @@ interface OutcomePageProps {}
 const OutcomePage: React.FC<OutcomePageProps> = () => {
   return (
     <Layout>
-      <OutcomePanel showProgressBar={false} showSaveButton={false} showFeedbackButton={false} />
+      <OutcomePanel showProgressBar={false} showSaveButton={false} />
     </Layout>
   );
 };


### PR DESCRIPTION
Removed the request for feedback modal on the outcome page, but added the feedback button back to the top of the page. 