### PR TITLE
Adding XM Cloud migration tool to the outcome page

### DIFF
--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -221,6 +221,14 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
         <RichTextOutput content={gameInfoContext.outcome.xmFeaturesIntro} />
       </Text>
       <SimpleGrid columns={3} minChildWidth="250px" spacing="md">
+        {/* Content migration tool */}
+        <LinkCard
+          link="https://developers.sitecore.com/downloads/xm-cloud#xm-to-xm-cloud-content-migration-tool"
+          title="XM to XM Cloud Content Migration tool"
+          description="Move content, media and user data from a source XM on-premises instance to a target XM Cloud environment."
+          buttonText="Download"
+        />
+
         {/*Rob Habraken SUGCON video*/}
         <YouTubeVideoDisplay videoId="vLAfx7dps_Q" />
 

--- a/src/components/ui/LinkCard/LinkCard.tsx
+++ b/src/components/ui/LinkCard/LinkCard.tsx
@@ -9,6 +9,7 @@ interface LinkCardProps {
   link: string;
   title: string;
   description?: string;
+  buttonText?: string;
 }
 
 export const LinkCard: FC<LinkCardProps> = ({ ...props }) => {
@@ -34,7 +35,7 @@ export const LinkCard: FC<LinkCardProps> = ({ ...props }) => {
           onClick={(e) => handleExternalLinkClick(e)}
         >
           <Link href={props.link} target="_blank" rel="noopener noreferrer">
-            Learn More
+            {props.buttonText ? props.buttonText : 'Learn more'}
           </Link>
         </Button>
       </CardBody>


### PR DESCRIPTION
XMC content migration tool now shows for all users on the outcome page. Also added an optional button text for the LinkCard so we can change it from the default.