### PR TITLE
Fix for Validation Issue after previous multi-select

### DIFF
--- a/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
+++ b/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
@@ -74,7 +74,11 @@ export const CurrentPrompt: FC<PromptProps> = ({ prompt, answerSelected }) => {
           {prompt?.options?.results != null && (
             <>
               {prompt?.optionType?.results[0].name === 'Checklist' && (
-                <MultiSelect multiSelectSubmit={multiSelectSubmit} options={prompt.options.results}></MultiSelect>
+                <MultiSelect
+                  currentPrompt={prompt.id}
+                  multiSelectSubmit={multiSelectSubmit}
+                  options={prompt.options.results}
+                ></MultiSelect>
               )}
               {prompt?.optionType?.results[0].name === 'Buttons' && (
                 <>

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -18,17 +18,23 @@ import {
 } from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import { IOption } from 'models';
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { FaInfo } from 'react-icons/fa';
 
 interface MultiSelectProps {
   options: IOption[];
   multiSelectSubmit?: (selectedOptions: IOption[]) => void;
+  currentPrompt?: string;
 }
 
-export const MultiSelect: FC<MultiSelectProps> = ({ options, multiSelectSubmit }) => {
+export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, multiSelectSubmit }) => {
   let [selectedOptions, setSelectedOptions] = useState<IOption[]>([]);
   const gameInfoContext = useGameInfoContext();
+
+  // Need to reset the selected options when the prompt changes
+  useEffect(() => {
+    setSelectedOptions([]);
+  }, [currentPrompt]);
 
   const handleOptionSelected = (option: IOption) => {
     const newCheckedArr = [...selectedOptions];


### PR DESCRIPTION
Since we were using the same reference of MultiSelect across prompts, we needed to add a useEffect, to set the selectedOptions back to empty as the prompt changes.  I thought this was a missing dependency array for a useEffect, but in this case, it was a missing useEffect that was needed.