### PR TITLE
Cleanup/console logs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "editor.insertSpaces": true,
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#a2decb",

--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -43,8 +43,8 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
       </Text>
       {requiredProducts && requiredProducts.length > 0 && (
         <Accordion size="lg" pb="20px" id="required-products" allowMultiple>
-          {requiredProducts.map((product: TargetProduct) => (
-            <AccordionItem>
+          {requiredProducts.map((product: TargetProduct, idx) => (
+            <AccordionItem key={idx}>
               <AccordionButton>
                 <Box as="span" flex="1" textAlign="left">
                   <Heading size="md" mb={2}>

--- a/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import { IOption } from 'models';
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { FaInfo } from 'react-icons/fa';
 
 interface IButtonGroupProps {
@@ -30,8 +30,8 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
       {options && (
         <>
           <SimpleGrid templateColumns={{ base: '1fr', md: '1fr 1fr', xl: '1fr 1fr 1fr' }} spacing={2}>
-            {options?.map((o: IOption) => (
-              <>
+            {options?.map((o: IOption, idx) => (
+              <React.Fragment key={idx}>
                 {o.tooltip && gameInfoContext.theme?.chakraTheme == 'fantasy' ? (
                   <>
                     <Show above="xl">
@@ -71,7 +71,7 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                     {o.label}
                   </Button>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </SimpleGrid>
         </>

--- a/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
+++ b/src/components/Prompts/CurrentPrompt/CurrentPrompt.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardFooter, Text } from '@chakra-ui/react';
+import { Box, Card, CardBody, CardFooter, Text } from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import { ButtonGroup, MultiSelect } from 'components/Prompts';
 import { RichTextOutput } from 'components/ui';
@@ -55,9 +55,9 @@ export const CurrentPrompt: FC<PromptProps> = ({ prompt, answerSelected }) => {
       >
         <CardBody>
           {prompt?.bodyText && (
-            <Text textAlign={'center'} marginBottom={'15px'}>
+            <Box textAlign={'center'} marginBottom={'15px'}>
               <RichTextOutput content={prompt.bodyText} />
-            </Text>
+            </Box>
           )}
 
           <Text

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -18,7 +18,7 @@ import {
 } from '@chakra-ui/react';
 import { useGameInfoContext } from 'components/Contexts';
 import { IOption } from 'models';
-import { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { FaInfo } from 'react-icons/fa';
 
 interface MultiSelectProps {
@@ -63,9 +63,8 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
             alignItems={'left'}
             marginLeft={{ base: gameInfoContext.theme?.chakraTheme == 'fantasy' ? '8px' : '0', sm: 0, md: 5, lg: -5 }}
           >
-            {options.map((option: IOption) => (
-              <>
-                {/* Center all the below elements */}
+            {options.map((option: IOption, idx) => (
+              <React.Fragment key={idx}>
                 {option.tooltip && gameInfoContext.theme?.chakraTheme == 'fantasy' ? (
                   <>
                     <Show above="xl">
@@ -132,7 +131,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
                     </Button>
                   </Container>
                 )}
-              </>
+              </React.Fragment>
             ))}
           </SimpleGrid>
         </VStack>

--- a/src/components/ui/ChooseCharacterDisplay/AvatarGallery/AvatarGallery.tsx
+++ b/src/components/ui/ChooseCharacterDisplay/AvatarGallery/AvatarGallery.tsx
@@ -21,7 +21,7 @@ export const AvatarGallery: FC<AvatarGalleryProps> = ({ avatars, toggledAvatarId
           {avatars?.map((avatar, i) => {
             const isToggled = avatar.id === toggledAvatarId;
             return (
-              <Box width={['80px', '80px', '100px']}>
+              <Box key={i} width={['80px', '80px', '100px']}>
                 {avatar !== undefined && (
                   <Button
                     key={avatar.id}

--- a/src/components/ui/HexagonItem/HexagonItem.tsx
+++ b/src/components/ui/HexagonItem/HexagonItem.tsx
@@ -12,7 +12,6 @@ import {
   PopoverTrigger,
   Show,
   Text,
-  chakra,
 } from '@chakra-ui/react';
 import { Products } from 'models/Config';
 import { TargetProduct } from 'models/OutcomeConditions';
@@ -40,10 +39,8 @@ export const HexagonItem: FC<HexagonItemProps> = ({ product, active = false }) =
           onClick={() => setIsOpen(!isOpen)}
           sx={{
             opacity: active ? 1 : 0.25,
-            webkitFilter:
-              'url(/images/hex-item-round-corners.svg#helix-round-borders) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
-            filter:
-              'url(/images/hex-item-round-corners.svg#helix-round-borders) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
+            webkitFilter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
+            filter: 'drop-shadow(0 1px 2px rgba(0, 0, 0, 0.6))',
             transition: 'opacity 0.3s',
             pointerEvents: active ? 'auto' : 'none',
           }}

--- a/src/components/ui/LandingPage/LandingPage.tsx
+++ b/src/components/ui/LandingPage/LandingPage.tsx
@@ -75,8 +75,8 @@ const LandingPage: React.FC = () => {
             mt={12}
             pb={12}
           >
-            {features.map((feature) => (
-              <FeatureCard heading={feature.heading} text={feature.text} />
+            {features.map((feature, idx) => (
+              <FeatureCard key={idx} heading={feature.heading} text={feature.text} />
             ))}
           </Grid>
         </Container>

--- a/src/lib/GTag.ts
+++ b/src/lib/GTag.ts
@@ -1,4 +1,5 @@
 import { AppConfig } from 'models/Config';
+import { consoleLogger } from 'utils/consoleLogger';
 
 declare global {
   interface Window {
@@ -11,7 +12,7 @@ export const pageView = (url: string) => {
     return;
   }
 
-  console.log('pageView', url);
+  consoleLogger('pageView', url);
 
   window.gtag('config', `${AppConfig.GaMeasurementId}`, {
     page_page: url,
@@ -23,7 +24,7 @@ export const event = (action: string, label: string, value: string) => {
     return;
   }
 
-  console.log('event', action, label, value);
+  consoleLogger('event', action, label, value);
 
   window.gtag('event', action, {
     event_label: label,

--- a/src/utils/consoleLogger.ts
+++ b/src/utils/consoleLogger.ts
@@ -1,0 +1,5 @@
+export const consoleLogger = (message: any, ...optionalParams: any[]) => {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(message, ...optionalParams);
+  }
+};


### PR DESCRIPTION
This PR fixes all the console.logs.  This includes:

- A new helper util, if you want to see the logs in dev but not in production, called consoleLogger
- I kept the console.logs associated with the Engage SDK, because I'd like to know when it's not configured correctly.
- Switched to the helper function for log outputs in GTag.ts
- I left a few console.logs that are in Jason's PR
- Fixed several Key={React idx issues}
- Fixed an issue where there was a Text wrapping the Rich Text component, which leads to a <p> wrapping an <Article> component, which isn't allowed.
- Removed the broken background image url that Jason had been seeing.