### PR TITLE
Implemented tracking of recommended products

### DIFF
--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -5,6 +5,7 @@ import { HexagonCollection, LayoutProps, TwoColumnLayout } from 'components/ui';
 import AvatarDisplay from 'components/ui/AvatarDisplay/AvatarDisplay';
 import { FeedbackModal } from 'components/ui/FeedbackModal/FeedbackModal';
 import * as GTag from 'lib/GTag';
+import { OutcomeConditions, TargetProduct } from 'models/OutcomeConditions';
 import router from 'next/router';
 import { FC, useEffect } from 'react';
 
@@ -34,6 +35,14 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
     );
 
     GTag.event('outcome_answers', 'Answers', JSON.stringify(gameInfoContext.answers));
+
+    let outcomeConditions = new OutcomeConditions(gameInfoContext);
+    const requiredProducts: TargetProduct[] = outcomeConditions.requiredProducts();
+
+    if (requiredProducts) {
+      tracker.TrackEvent('outcome_recommended_products', { requiredProducts: JSON.stringify(requiredProducts) });
+      GTag.event('outcome_recommended_products', 'Recommended Products', JSON.stringify(requiredProducts));
+    }
   }, []);
 
   return (

--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -40,8 +40,10 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
     const requiredProducts: TargetProduct[] = outcomeConditions.requiredProducts();
 
     if (requiredProducts) {
-      tracker.TrackEvent('outcome_recommended_products', { requiredProducts: JSON.stringify(requiredProducts) });
-      GTag.event('outcome_recommended_products', 'Recommended Products', JSON.stringify(requiredProducts));
+      requiredProducts.forEach((product) => {
+        tracker.TrackEvent('outcome_required_product', { requiredProduct: product });
+        GTag.event('outcome_required_product', 'Required Product', product);
+      });
     }
   }, []);
 

--- a/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
+++ b/src/components/Outcomes/OutcomePanel/OutcomePanel.tsx
@@ -42,7 +42,7 @@ export const OutcomePanel: FC<OutcomePanelProps> = (props) => {
     if (requiredProducts) {
       requiredProducts.forEach((product) => {
         tracker.TrackEvent('outcome_required_product', { requiredProduct: product });
-        GTag.event('outcome_required_product', 'Required Product', product);
+        GTag.event('outcome_required_product', product, product);
       });
     }
   }, []);


### PR DESCRIPTION
Added Google Analytics tracking and Engage SDK tracking for recommended products.  This gets logged as a custom event on the outcome page when it loads.  I was able to confirm this getting logged in both analytics tools.