### PR TITLE
Make sure Cookie isn't Enforced

### DIFF
--- a/src/components/Contexts/EngageTrackerContext/EngageTrackerContext.tsx
+++ b/src/components/Contexts/EngageTrackerContext/EngageTrackerContext.tsx
@@ -22,29 +22,26 @@ export const EngageTrackerProvider: FC<EngageTrackerProviderProps> = ({ children
   const loadEngageTracker = useCallback(async () => {
     setLoading(true);
 
-    if (
-      !AppConfig.SitecoreCdpClientKey ||
-      !AppConfig.SitecoreCdpCookieDomain ||
-      !AppConfig.SitecoreCdpPos ||
-      !AppConfig.SitecoreCdpTargetUrl
-    ) {
+    if (!AppConfig.SitecoreCdpClientKey || !AppConfig.SitecoreCdpPos || !AppConfig.SitecoreCdpTargetUrl) {
       isTrackerEnabled.current = false;
-      console.log('SitecoreCdpClientKey', AppConfig.SitecoreCdpClientKey);
-      console.log('SitecoreCdpCookieDomain', AppConfig.SitecoreCdpCookieDomain);
-      console.log('SitecoreCdpPos', AppConfig.SitecoreCdpPos);
-      console.log('SitecoreCdpTargetUrl', AppConfig.SitecoreCdpTargetUrl);
       console.log('Engage Tracker not configured correctly');
     }
 
     if (isTrackerEnabled.current) {
-      const tracker: Engage = await init({
-        clientKey: AppConfig.SitecoreCdpClientKey!,
-        targetURL: AppConfig.SitecoreCdpTargetUrl!,
-        cookieDomain: AppConfig.SitecoreCdpCookieDomain!,
-        pointOfSale: AppConfig.SitecoreCdpPos!,
+      const initConfig: any = {
+        clientKey: AppConfig.SitecoreCdpClientKey,
+        targetURL: AppConfig.SitecoreCdpTargetUrl,
+        pointOfSale: AppConfig.SitecoreCdpPos,
         cookieExpiryDays: 365,
         forceServerCookieMode: false,
-      });
+        webPersonalization: false,
+      };
+
+      if (AppConfig.SitecoreCdpCookieDomain) {
+        initConfig.cookieDomain = AppConfig.SitecoreCdpCookieDomain;
+      }
+
+      const tracker: Engage = await init(initConfig);
 
       setEngageTracker(tracker);
     }

--- a/src/components/Contexts/EngageTrackerContext/EngageTrackerContext.tsx
+++ b/src/components/Contexts/EngageTrackerContext/EngageTrackerContext.tsx
@@ -29,6 +29,10 @@ export const EngageTrackerProvider: FC<EngageTrackerProviderProps> = ({ children
       !AppConfig.SitecoreCdpTargetUrl
     ) {
       isTrackerEnabled.current = false;
+      console.log('SitecoreCdpClientKey', AppConfig.SitecoreCdpClientKey);
+      console.log('SitecoreCdpCookieDomain', AppConfig.SitecoreCdpCookieDomain);
+      console.log('SitecoreCdpPos', AppConfig.SitecoreCdpPos);
+      console.log('SitecoreCdpTargetUrl', AppConfig.SitecoreCdpTargetUrl);
       console.log('Engage Tracker not configured correctly');
     }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,18 @@
+import { useEngageTracker } from 'components/Contexts';
 import LandingPage from 'components/ui/LandingPage/LandingPage';
-import React from 'react';
+import * as GTag from 'lib/GTag';
+import { consoleLogger } from 'utils/consoleLogger';
 
 const App = () => {
-  return (
-    <LandingPage />
-  );
+  const tracker = useEngageTracker();
+
+  tracker.TrackPageView({ page: '/', channel: 'WEB', language: 'EN', currency: 'USD' }).catch((err) => {
+    consoleLogger('TrackPageView Err', err);
+  });
+
+  GTag.pageView('/');
+
+  return <LandingPage />;
 };
 
 export default App;


### PR DESCRIPTION
Forgot this was the first time I implemented Engage, and Developer Portal was after.  I learned on the Developer Portal implementation that if you enforce the cookie, then Vercel just doesn't work correctly, and you'd want the value to not be set (and then it works fine).  And because I wasn't setting it, that's why I was getting that error of it not being configured correctly.

So long story short, this removes that requirement, so now this should work in all Vercel preview environments as well as in production.

To test, make sure you can go to the environment, make sure nothing extra is displaying that you wouldn't expect, and then go into the console and type `Engage.getBrowserId()` and make sure it returns an Id.  If you would like to take that further, send it to me and I'll send over what it logged and confirm it made it into the correct tenant.