### PR TITLE
Display tooltip regardless of theme choice

### DIFF
--- a/src/chakra/theme/corporate/theme.ts
+++ b/src/chakra/theme/corporate/theme.ts
@@ -7,6 +7,8 @@ import { buttonTheme } from './button';
 
 export const corporateTheme = extendTheme(
   {
+    initialColorMode: 'light',
+    useSystemColorMode: false,
     styles: {},
     colors: {},
     components: {

--- a/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
@@ -32,7 +32,7 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
           <SimpleGrid templateColumns={{ base: '1fr', md: '1fr 1fr', xl: '1fr 1fr 1fr' }} spacing={2}>
             {options?.map((o: IOption, idx) => (
               <React.Fragment key={idx}>
-                {o.tooltip && gameInfoContext.theme?.chakraTheme == 'fantasy' ? (
+                {o.tooltip ? (
                   <>
                     <Show above="xl">
                       <Tooltip key={o.id} label={o.tooltip}>
@@ -42,8 +42,8 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                       </Tooltip>
                     </Show>
                     <Hide above="xl">
-                      <HStack spacing={0}>
-                        <Button key={o.id} value={o.value} mx={5} onClick={optionSelectEvent} variant="solid" size="lg">
+                    <HStack spacing={0} width={'100%'} justifyContent={'space-between'}>
+                        <Button key={o.id} value={o.value} m={1} onClick={optionSelectEvent} width="100%" variant="solid" size="lg">
                           {o.label}
                         </Button>
                         <Popover placement="top-start" closeOnBlur>
@@ -59,7 +59,6 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                           </PopoverTrigger>
                           <PopoverContent backgroundImage={'/fantasy/tooltip.svg'} background={'transparent'}>
                             <PopoverArrow />
-
                             <PopoverBody>{o.tooltip}</PopoverBody>
                           </PopoverContent>
                         </Popover>

--- a/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
@@ -25,6 +25,9 @@ interface IButtonGroupProps {
 
 export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent }) => {
   const gameInfoContext = useGameInfoContext();
+
+  const buttonWidth = '80%';
+
   return (
     <Container maxWidth={'100%'}>
       {options && (
@@ -36,16 +39,17 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                   <>
                     <Show above="xl">
                       <Tooltip key={o.id} label={o.tooltip}>
-                        <Button key={o.id} value={o.value} mx={5} onClick={optionSelectEvent} variant="solid" size="lg">
+                        <Button key={o.id} value={o.value} m={1} onClick={optionSelectEvent} variant="solid" size="lg">
                           {o.label}
                         </Button>
                       </Tooltip>
                     </Show>
                     <Hide above="xl">
-                    <HStack spacing={0} width={'100%'} justifyContent={'space-between'}>
-                        <Button key={o.id} value={o.value} m={1} onClick={optionSelectEvent} width="100%" variant="solid" size="lg">
+                      <HStack spacing={0} width={'100%'} justifyContent={'space-between'}>
+                        <Button key={o.id} value={o.value} m={1} onClick={optionSelectEvent} width={{ base: buttonWidth, xl: '100%' }} variant="solid" size="lg">
                           {o.label}
                         </Button>
+
                         <Popover placement="top-start" closeOnBlur>
                           <PopoverTrigger>
                             <IconButton
@@ -66,7 +70,7 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                     </Hide>
                   </>
                 ) : (
-                  <Button key={o.id} value={o.value} mx={5} onClick={optionSelectEvent} variant="solid" size="lg">
+                  <Button key={o.id} value={o.value} width={{ base: buttonWidth, xl: '100%' }} m={1} onClick={optionSelectEvent} variant="solid" size="lg">
                     {o.label}
                   </Button>
                 )}

--- a/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/Prompts/ButtonGroup/ButtonGroup.tsx
@@ -57,7 +57,7 @@ export const ButtonGroup: FC<IButtonGroupProps> = ({ options, optionSelectEvent 
                               icon={<FaInfo size={18} />}
                             ></IconButton>
                           </PopoverTrigger>
-                          <PopoverContent backgroundImage={'/fantasy/tooltip.svg'} background={'transparent'}>
+                          <PopoverContent>
                             <PopoverArrow />
                             <PopoverBody>{o.tooltip}</PopoverBody>
                           </PopoverContent>

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -47,7 +47,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
     setSelectedOptions(newCheckedArr);
   };
 
-  const buttonWidth = '90%';
+  const buttonWidth = '88%';
 
   return (
     <>
@@ -122,7 +122,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
                       key={option.id}
                       value={option.value}
                       m={1}
-                      width={{ base: buttonWidth, md: '100%' }}
+                      width={{ base: buttonWidth, xl: '100%' }}
                       isActive={selectedOptions.includes(option) ? true : false}
                       onClick={() => handleOptionSelected(option)}
                       variant={{ base: 'solid' }}

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -65,7 +65,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
           >
             {options.map((option: IOption, idx) => (
               <React.Fragment key={idx}>
-                {option.tooltip && gameInfoContext.theme?.chakraTheme == 'fantasy' ? (
+                {option.tooltip ? (
                   <>
                     <Show above="xl">
                       <Tooltip key={option.id} label={option.tooltip}>

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -108,7 +108,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
                               icon={<FaInfo size={14} />}
                             ></IconButton>
                           </PopoverTrigger>
-                          <PopoverContent backgroundImage={'/fantasy/tooltip.svg'} background={'transparent'}>
+                          <PopoverContent>
                             <PopoverArrow />
                             <PopoverBody>{option.tooltip}</PopoverBody>
                           </PopoverContent>

--- a/src/components/Prompts/MultiSelect/MultiSelect.tsx
+++ b/src/components/Prompts/MultiSelect/MultiSelect.tsx
@@ -83,7 +83,7 @@ export const MultiSelect: FC<MultiSelectProps> = ({ currentPrompt, options, mult
                     </Show>
                     <Hide above="xl">
                       <HStack spacing={0} width={'100%'} justifyContent={'space-between'}>
-                        <Container width={{ base: buttonWidth, md: '100%' }}>
+                        <Container width={{ base: buttonWidth, xl: '100%' }}>
                           <Button
                             key={option.id}
                             value={option.value}


### PR DESCRIPTION
Removed the check for fantasy theme when displaying tooltips. Also improved the mobile view UI for ButtonGroup.tsx. Essentially brought over styling changes that were already in MultiSelect.tsx.

Fixes #122 