### PR TITLE
Added Next.js guide by Meng Hak to outcome generator

### DIFF
--- a/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
+++ b/src/components/Outcomes/OutcomeGenerator/OutcomeGenerator.tsx
@@ -15,7 +15,7 @@ import { LinkCard, RichTextOutput, YouTubeVideoDisplay } from 'components/ui';
 import { ExperienceEdgeOption, OutcomeConditions, TargetProduct } from 'models/OutcomeConditions';
 import { FC } from 'react';
 
-interface OutcomeGeneratorProps { }
+interface OutcomeGeneratorProps {}
 
 export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
   const gameInfoContext = useGameInfoContext();
@@ -261,6 +261,10 @@ export const OutcomeGenerator: FC<OutcomeGeneratorProps> = () => {
           <LinkCard
             link="https://thetombomb.com/posts/nextjs-hosting-alternatives"
             title="Beyond Vercel: Hosting Alternatives for Next.js"
+          />
+          <LinkCard
+            link="https://sitecore-nextjs-guide.hakmeng.com"
+            title="Beginner's Guide to developing with Sitecore Next.js (Meng Hak)"
           />
         </ConditionalResponse>
         <ConditionalResponse condition={outcomeConditions.serializationUsed.tds}>


### PR DESCRIPTION
On the Outcome page, will now show a community guide for Sitecore Next.js development. The Next.js guide will only display if the user wants to move to Next.js from a non-supported existing framework.

Fixes #101 