### PR TITLE
Removing Forms from the check for if Send should be recommended

### DIFF
--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -209,7 +209,7 @@ export class OutcomeConditions {
    * Looks at selections to determine if some sort of marketing automation feature is in use
    */
   isMarketingAutomation(): boolean {
-    return this.xpFeaturesUsed.forms || this.xpFeaturesUsed.exm || this.xpFeaturesUsed.marketingAutomation;
+    return this.xpFeaturesUsed.exm || this.xpFeaturesUsed.marketingAutomation;
   }
 
   /**


### PR DESCRIPTION
Minor change so that if Forms are selected as a feature of XP being used then Send is no longer recommended.