### PR TITLE
Fix for 11th Prompt

### DIFF
--- a/src/GraphQL/Queries/Prompts.gql
+++ b/src/GraphQL/Queries/Prompts.gql
@@ -72,7 +72,10 @@ query GetAllPromptsQuery {
 }
 
 query GetPromptsByThemeAndPersonaQuery($themeId: ID!, $personaId: ID!) {
-  allPrompt(where: { AND: [{ theme: { prompt_ids: $themeId } }, { persona: { prompt_ids: $personaId } }] }) {
+  allPrompt(
+    first: 1000
+    where: { AND: [{ theme: { prompt_ids: $themeId } }, { persona: { prompt_ids: $personaId } }] }
+  ) {
     results {
       ...PromptDetails
     }


### PR DESCRIPTION
Issue is that when you add the new connect prompt it replaces the 10th prompt for XC questions with the disabled prompt (which doesn't help anything).  So I've upped the limit to 1000, which I doubt we'll ever reach.  There could be other content we are pulling from CH1 that could run into limits as well.