### PR TITLE
Read data about selected integration connectors

### DIFF
--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -8,6 +8,7 @@ describe('Outcome Page', () => {
     cy.get('[value="xm"]').click();
     cy.get('[value="nosecuredpages"]').click();
     cy.get('[value="search-no"]').click();
+    cy.get('[value="xp-connect-none"]').click();
     cy.get('[value="scs"]').click();
     cy.get('[value="vuejs"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();

--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -9,6 +9,7 @@ describe('Outcome Page', () => {
     cy.get('[value="nosecuredpages"]').click();
     cy.get('[value="search-no"]').click();
     cy.get('[value="xp-connect-none"]').click();
+    cy.get('.css-1baj6k3 > .chakra-button').click();
     cy.get('[value="scs"]').click();
     cy.get('[value="vuejs"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();
@@ -45,6 +46,8 @@ describe('Outcome Page', () => {
     cy.get('[value="securityloginrequired"]').click();
     cy.get('[value="historicalpersonalize90"]').click();
     cy.get('[value="search-index"]').click();
+    cy.get('[value="xp-connect-none"]').click();
+    cy.get('.css-1baj6k3 > .chakra-button').click();
     cy.get('[value="unicorn"]').click();
     cy.get('[value="netcore"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();

--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -9,7 +9,7 @@ describe('Outcome Page', () => {
     cy.get('[value="nosecuredpages"]').click();
     cy.get('[value="search-no"]').click();
     cy.get('[value="xp-connect-none"]').click();
-    cy.get('.css-1baj6k3 > .chakra-button').click();
+    cy.get('.css-gmuwbf > .chakra-button').click();
     cy.get('[value="scs"]').click();
     cy.get('[value="vuejs"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();
@@ -47,7 +47,7 @@ describe('Outcome Page', () => {
     cy.get('[value="historicalpersonalize90"]').click();
     cy.get('[value="search-index"]').click();
     cy.get('[value="xp-connect-none"]').click();
-    cy.get('.css-1baj6k3 > .chakra-button').click();
+    cy.get('.css-gmuwbf > .chakra-button').click();
     cy.get('[value="unicorn"]').click();
     cy.get('[value="netcore"]').click();
     cy.get('.css-gmuwbf > .chakra-button').click();

--- a/src/lib/GameContextParser.ts
+++ b/src/lib/GameContextParser.ts
@@ -48,6 +48,7 @@ export class GameContextParser {
     this.parseContext_ExperienceEdge(gameInfoContext, outcomeConditions);
     this.parseContext_SiteSearchUsed(gameInfoContext, outcomeConditions);
     this.parseContext_SerializationUsed(gameInfoContext, outcomeConditions);
+    this.parseContext_ConnectorsUsed(gameInfoContext, outcomeConditions);
   }
 
   /**
@@ -221,6 +222,51 @@ export class GameContextParser {
       outcomeConditions.serializationUsed.scs = serializationUsedOptions.value.includes('scs');
       outcomeConditions.serializationUsed.tds = serializationUsedOptions.value.includes('tds');
       outcomeConditions.serializationUsed.unicorn = serializationUsedOptions.value.includes('unicorn');
+    }
+  }
+
+  /**
+   * Check for what type of integration connection modules are in the solution. 
+   * This will drive them towards a Connect implementation (likely)
+   * @param gameInfoContext: This is the current context which contains the prompts and answers
+   * @param outcomeConditions: This is where the results should be stored
+   */
+  parseContext_ConnectorsUsed(gameInfoContext: GameInfoContextType, outcomeConditions: OutcomeConditions) {
+    var connectorsUsedOptions = gameInfoContext.answers?.find(
+      (x: IAnswer) => x.promptQuestionId == PromptMappings.connectorsUsed
+    );
+    if (connectorsUsedOptions != undefined) {
+      outcomeConditions.connectorsUsed.none = connectorsUsedOptions.value.includes('xp-connect-none');
+
+      //Only read the other options if None is not selected. Blank out all selections if user selected None
+      //Technically, because it's a multi-select, they could select a connector and None, but we will use 'None' to rule out other selections
+      if (outcomeConditions.connectorsUsed.none) {
+        outcomeConditions.connectorsUsed = {
+          none: true,
+          sfmc: false,
+          sfcrm: false,
+          contenthub: false,
+          dam: false,
+          cmp: false,
+          dynamics365commerce: false,
+          dynamics365sales: false,
+          komfo: false,
+          sharepoint: false
+        };
+      }
+      //If they didn't select None, read the rest of their selections
+      else {
+        outcomeConditions.connectorsUsed.sfmc = connectorsUsedOptions.value.includes('xp-connect-sfmc');
+        outcomeConditions.connectorsUsed.sfcrm = connectorsUsedOptions.value.includes('xp-connect-sfcrm');
+        outcomeConditions.connectorsUsed.contenthub = connectorsUsedOptions.value.includes('xp-connect-contenthub');
+        outcomeConditions.connectorsUsed.dam = connectorsUsedOptions.value.includes('xp-connect-dam');
+        outcomeConditions.connectorsUsed.cmp = connectorsUsedOptions.value.includes('xp-connect-cmp');
+        outcomeConditions.connectorsUsed.dynamics365commerce = connectorsUsedOptions.value.includes('xp-commerce-dynamics365-commerce');
+        outcomeConditions.connectorsUsed.dynamics365sales = connectorsUsedOptions.value.includes('xp-connect-dynamics365sales');
+        outcomeConditions.connectorsUsed.komfo = connectorsUsedOptions.value.includes('xp-komfo');
+        outcomeConditions.connectorsUsed.sharepoint = connectorsUsedOptions.value.includes('xp-sharepoint');
+      }
+
     }
   }
 }

--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -75,7 +75,7 @@ export interface IConnectorsUsed {
   contenthub: boolean,
   dam: boolean,
   cmp: boolean,
-  dynamics365: boolean,
+  dynamics365commerce: boolean,
   dynamics365sales: boolean,
   komfo: boolean,
   sharepoint: boolean,
@@ -181,7 +181,7 @@ export class OutcomeConditions {
       contenthub: false,
       dam: false,
       cmp: false,
-      dynamics365: false,
+      dynamics365commerce: false,
       dynamics365sales: false,
       komfo: false,
       sharepoint: false

--- a/src/models/PromptMappings.ts
+++ b/src/models/PromptMappings.ts
@@ -9,4 +9,5 @@ export enum PromptMappings {
   siteSearchUsed = 'sitesearch',
   historicalPersonalization = 'historicalpersonalizationneeds',
   serializationUsed = 'serialization',
+  connectorsUsed = 'integrationmodules',
 }


### PR DESCRIPTION
This change will read the data from the user and parse it into objects so that can be used in Outcomes later to make decisions on which tiles to show or which content recommendations to make. 

Additionally, this fixes the Cypress tests so that they can incorporate the new question into the flow.