### PR TITLE
Add Connect as recommended product

### DIFF
--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -61,4 +61,27 @@ describe('Outcome Page', () => {
     cy.get('#required-products').children().should('contain', 'CDP');
     cy.get('#required-products').children().should('contain', 'Send');
   });
+
+  it('require connect', () => {
+    cy.visit('/');
+    cy.get('#start').click();
+    cy.get('[value="Developer"]').click();
+    cy.get(':nth-child(9) > .chakra-button').click();
+    cy.get('.chakra-container > :nth-child(3) > .chakra-button').click();
+    cy.get('[value="xm"]').click();
+    cy.get('[value="nosecuredpages"]').click();
+    cy.get('[value="search-no"]').click();
+    cy.get('[value="xp-connect-sfmc"]').click();
+    cy.get('.css-gmuwbf > .chakra-button').click();
+    cy.get('[value="scs"]').click();
+    cy.get('[value="vuejs"]').click();
+    cy.get('.css-gmuwbf > .chakra-button').click();
+    cy.get('[value="yesexperienceedge"]').click();
+    cy.wait(5000);
+    cy.get('.chakra-modal__close-btn').click();
+    cy.get('#required-products').should('exist').children().should('have.length', 2);
+    cy.get('#required-products').children().should('contain', 'XM Cloud');
+    cy.get('#required-products').children().should('contain', 'Connect');
+    cy.get('#shareButton').click();
+  });
 });

--- a/cypress/e2e/OutcomeFlow/outcome.cy.ts
+++ b/cypress/e2e/OutcomeFlow/outcome.cy.ts
@@ -36,7 +36,6 @@ describe('Outcome Page', () => {
     cy.get('[value="exm"]').click();
     cy.get('[value="forms"]').click();
     cy.get('[value="customanalyticsdashboards"]').click();
-    cy.get('[value="externaldatasystems"]').click();
     cy.get('[value="historicalpersonalization"]').click();
     cy.get('[value="patterncards"]').click();
     cy.get('[value="customrules"]').click();

--- a/src/components/ui/HexagonCollection/HexagonCollection.tsx
+++ b/src/components/ui/HexagonCollection/HexagonCollection.tsx
@@ -75,6 +75,12 @@ export const HexagonCollection: FC<HexagonCollectionProps> = ({ classStyles }) =
               }
             />
             <HexagonItem
+              product={TargetProduct.connect}
+              active={
+                requiredProducts != undefined && requiredProducts.find((x) => x == TargetProduct.connect) ? true : false
+              }
+            />
+            <HexagonItem
               product={TargetProduct.orderCloud}
               active={
                 requiredProducts != undefined && requiredProducts.find((x) => x == TargetProduct.orderCloud)

--- a/src/lib/GameContextParser.ts
+++ b/src/lib/GameContextParser.ts
@@ -251,7 +251,8 @@ export class GameContextParser {
           dynamics365commerce: false,
           dynamics365sales: false,
           komfo: false,
-          sharepoint: false
+          sharepoint: false,
+          customDEF: false,
         };
       }
       //If they didn't select None, read the rest of their selections
@@ -265,6 +266,7 @@ export class GameContextParser {
         outcomeConditions.connectorsUsed.dynamics365sales = connectorsUsedOptions.value.includes('xp-connect-dynamics365sales');
         outcomeConditions.connectorsUsed.komfo = connectorsUsedOptions.value.includes('xp-komfo');
         outcomeConditions.connectorsUsed.sharepoint = connectorsUsedOptions.value.includes('xp-sharepoint');
+        outcomeConditions.connectorsUsed.customDEF = connectorsUsedOptions.value.includes('connect-custom-def');
       }
 
     }

--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -253,6 +253,17 @@ export class OutcomeConditions {
   }
 
   /**
+   * Analyzes current answers to determine if the solution has some form of external system integration
+   * Any use of Data Exchange Framework or Sitecore external integration module also qualifies for migration
+   */
+  hasSystemIntegration(): boolean {
+    return (
+      this.xpFeaturesUsed.externalDataSystems ||
+      !this.connectorsUsed.none
+    );
+  }
+
+  /**
    * Returns a list of products that can be migrated to.
    * NOTE: Several product options don't have Prompts yet that can help lead to a result, so are not included.
    * @returns
@@ -288,6 +299,11 @@ export class OutcomeConditions {
     //If they have XC, regardless of features selected, we direct the customer to OrderCloud
     if (this.isXC) {
       products.push(TargetProduct.orderCloud);
+    }
+
+    //If they are using some form of integration, we direct towards migrating to Sitecore Connect
+    if (this.hasSystemIntegration()) {
+      products.push(TargetProduct.connect);
     }
 
     return products;

--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -255,13 +255,19 @@ export class OutcomeConditions {
   }
 
   /**
-   * Analyzes current answers to determine if the solution has some form of external system integration
+   * Analyzes current answers to determine if the solution has some form of external system integration that could be moved to Connect.
    * Any use of Data Exchange Framework or Sitecore external integration module also qualifies for migration
+   * Not required for some connectors which are included in other products (such as DAM integration)
    */
-  hasSystemIntegration(): boolean {
+  requiresConnect(): boolean {
     return (
       this.xpFeaturesUsed.externalDataSystems ||
-      !this.connectorsUsed.none
+      this.connectorsUsed.customDEF ||
+      this.connectorsUsed.dynamics365commerce ||
+      this.connectorsUsed.dynamics365sales ||
+      this.connectorsUsed.komfo ||
+      this.connectorsUsed.sfcrm ||
+      this.connectorsUsed.sfmc
     );
   }
 
@@ -304,7 +310,7 @@ export class OutcomeConditions {
     }
 
     //If they are using some form of integration, we direct towards migrating to Sitecore Connect
-    if (this.hasSystemIntegration()) {
+    if (this.requiresConnect()) {
       products.push(TargetProduct.connect);
     }
 

--- a/src/models/OutcomeConditions.ts
+++ b/src/models/OutcomeConditions.ts
@@ -79,6 +79,7 @@ export interface IConnectorsUsed {
   dynamics365sales: boolean,
   komfo: boolean,
   sharepoint: boolean,
+  customDEF: boolean,
 }
 
 export enum ExperienceEdgeOption {
@@ -184,7 +185,8 @@ export class OutcomeConditions {
       dynamics365commerce: false,
       dynamics365sales: false,
       komfo: false,
-      sharepoint: false
+      sharepoint: false,
+      customDEF: false
     };
 
     //If a gameInfoContext was provided, initialize all data from the answers in the context


### PR DESCRIPTION
This pull request will add the capability for Connect to be suggested as a recommended product. There will not be any guides related to the product added at this time, this is only for the 'hexagon' that shows in the recommended products and the listing on the Outcome page.

A new E2E Cypress Test is also added to test that the product is added into the recommended products list on the Outcome page.